### PR TITLE
Stop using Contrail PPA

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -562,6 +562,7 @@ contrail::vrouter::metadata_proxy_secret: "%{hiera('nova_metadata_proxy_secret')
 contrail::vrouter::keystone_admin_password: "%{hiera('admin_password')}"
 
 contrail::manage_repo: false
+contrail::vrouter::manage_repo: "%{hiera('contrail::manage_repo')}"
 contrail::neutron_ip: "%{hiera('neutron_public_address')}"
 
 ##

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -561,13 +561,7 @@ contrail::nova_metadata_address: "lb.nova.service.consul"
 contrail::vrouter::metadata_proxy_secret: "%{hiera('nova_metadata_proxy_secret')}"
 contrail::vrouter::keystone_admin_password: "%{hiera('admin_password')}"
 
-##
-# Currently we have some dependency packages missing from rustedhalo, so they
-# are taken from opencontrail ppa. This can be made false after we have all
-# code.
-##
-
-contrail::manage_repo: true
+contrail::manage_repo: false
 contrail::neutron_ip: "%{hiera('neutron_public_address')}"
 
 ##

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -562,7 +562,7 @@ contrail::vrouter::metadata_proxy_secret: "%{hiera('nova_metadata_proxy_secret')
 contrail::vrouter::keystone_admin_password: "%{hiera('admin_password')}"
 
 contrail::manage_repo: false
-contrail::vrouter::manage_repo: "%{hiera('contrail::manage_repo')}"
+contrail::vrouter::manage_repo: false
 contrail::neutron_ip: "%{hiera('neutron_public_address')}"
 
 ##


### PR DESCRIPTION
Contrail PPA was updated to 2.0. We're not quite ready to make that switch yet and our stuff stopped working, because we were mixing 1.10 with 2.0. Stop using the PPA and use the rustedhalo stuff instead. I've filled in the gaps in rustedhalo to make this work again.