### PR TITLE
Change path to hiera data

### DIFF
--- a/build_scripts/deploy.sh
+++ b/build_scripts/deploy.sh
@@ -71,9 +71,10 @@ if [ -n "${puppet_modules_source_repo}" ]; then
   time gem install librarian-puppet-simple --no-ri --no-rdoc;
   mkdir -p /etc/puppet/manifests.overrides
   cp /tmp/rjil/site.pp /etc/puppet/manifests.overrides/
-  mkdir -p /etc/puppet/hiera
+  mkdir -p /etc/puppet/hiera.overrides
+  sed  -i "s/  :datadir: \/etc\/puppet\/hiera\/data/  :datadir: \/etc\/puppet\/hiera.overrides\/data/" /tmp/rjil/hiera/hiera.yaml
   cp /tmp/rjil/hiera/hiera.yaml /etc/puppet
-  cp -Rvf /tmp/rjil/hiera/data /etc/puppet/hiera
+  cp -Rvf /tmp/rjil/hiera/data /etc/puppet/hiera.overrides
   mkdir -p /etc/puppet/modules.overrides/rjil
   cp -Rvf /tmp/rjil/* /etc/puppet/modules.overrides/rjil/
   time librarian-puppet install --puppetfile=/tmp/rjil/Puppetfile --path=/etc/puppet/modules.overrides


### PR DESCRIPTION
Previously, for gate tests, where hiera data should
be copied from source, it was being put in the regular
directory which could be overridden in cases where a
package upgrade for jiocloud-puppet became available
during a gate test run (b/c that package's hiera
data would override the data being tested)

This resolves the issue by ensuring that when code
is used from git, it puts it's hiera data in
hiera.overrides.