### PR TITLE
Added host autocompletion for ssh and host commands

### DIFF
--- a/files/bash_completion.d_host_complete
+++ b/files/bash_completion.d_host_complete
@@ -1,0 +1,27 @@
+##
+# To autocomplete host list for ssh and host commands.
+# NOTE: this will remove autocompletion of other options, which need to be
+# fixed.
+#
+_host_list()
+{
+    local cur prev host_list
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    from_consul=`curl -s http://localhost:8500/v1/agent/members | python -m json.tool | awk 'BEGIN {print " "} /"Name"/ {gsub ("[\",]","",$2); print $2}' | sed -r 's/ +/\n/g'`
+    from_hosts=`awk '!/^#/ {print $0 }' /etc/hosts | sed -r 's/ +/\n/g'`
+
+    case ${COMP_WORDS[1]} in
+        *)
+            COMPREPLY=( $( compgen -W "$from_consul $from_hosts" | grep "^$cur"
+) )
+            ;;
+    esac
+
+    return 0
+
+}
+complete -F _host_list ssh
+complete -F _host_list host

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -65,4 +65,16 @@ class rjil::system(
     subscribe   => File_line['domain_search'],
   }
 
+  ##
+  # autocompletion of hostnames for ssh and host commands.
+  # TODO: this will remove the autocompletion for commandline options, which
+  # need to be fixed.
+  ##
+  file { '/etc/bash_completion.d/host_complete':
+    ensure        => file,
+    owner         => root,
+    group         => root,
+    mode          => 644,
+    source        => "puppet:///modules/${module_name}/bash_completion.d_host_complete"
+  }
 }

--- a/spec/classes/system_spec.rb
+++ b/spec/classes/system_spec.rb
@@ -30,6 +30,7 @@ describe 'rjil::system' do
       should contain_file('/etc/issue')
       should contain_file('/etc/issue.net')
       should contain_file('/usr/lib/jiocloud/tests/check_timezone.sh')
+      should contain_file('/etc/bash_completion.d/host_complete')
       should contain_class('timezone')
       should contain_class('rjil::system::apt')
       should contain_class('rjil::system::accounts')


### PR DESCRIPTION
It will take host inputs from consul as well as /etc/hosts and use for
bash autocompletion.

This should fix #299

NOTE: this file can be distributed in a package also.