### PR TITLE
do not rely on default vagrant mount

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |config|
 
       # This seems wrong - Soren
       config.vm.provision 'shell', :inline =>
-         'cp /vagrant/hiera/hiera.yaml /etc/puppet'
+         'cp /etc/puppet/hiera/hiera.yaml /etc/puppet'
 
       config.vm.host_name = "#{node_name}.domain.name"
       ['consul'].each do |x|


### PR DESCRIPTION
copy hiera.yaml from our explicit hiera mount