### PR TITLE
Configure vagrant VM resources using layouts and maps

### DIFF
--- a/environment/vagrant-vbox.map.yaml
+++ b/environment/vagrant-vbox.map.yaml
@@ -1,0 +1,15 @@
+image:
+  virtualbox:
+    trusty: 'ubuntu/trusty64'
+  lxc:
+    trusty: 'fgrehm/trusty64-lxc'
+flavor:
+  small:
+    ram: 1024
+    cpu: 1
+  medium:
+    ram: 2046
+    cpu: 1
+  large:
+    ram: 4096
+    cpu: 2


### PR DESCRIPTION
This patch makes vagrant to see the resources mentioned in the layout yaml file
(e.g. environments/full.yaml) and then map to map yaml file (e.g
environments/vagrant-vbox.yaml) for vm resources. So vagrant will be following
somewhat similar method for resource configuration in other environments.

This is also useful to build a hybrid vagrant environment which contain vms and
containers for appropriate machines.