### PR TITLE
Added validation checks for contrail-svc-mon

### DIFF
--- a/files/tests/contrail-svc-mon.sh
+++ b/files/tests/contrail-svc-mon.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/lib/nagios/plugins/check_http -H localhost -p 8088 -u /svc_mon_introspect.xml 

--- a/manifests/contrail/server.pp
+++ b/manifests/contrail/server.pp
@@ -9,7 +9,8 @@ class rjil::contrail::server () {
   $contrail_tests = ['ifmap.sh','contrail-analytics.sh','contrail-api.sh',
                       'contrail-control.sh','contrail-discovery.sh',
                       'contrail-dns.sh','contrail-schema.sh',
-                      'contrail-webui-webserver.sh','contrail-webui-jobserver.sh']
+                      'contrail-webui-webserver.sh','contrail-webui-jobserver.sh',
+                      'contrail-svc-mon.sh']
   rjil::test {$contrail_tests:}
 
   include ::contrail


### PR DESCRIPTION
This patch adds validation checks for contrail-svc-mon.

This one is dependant on jiocloud/contrail#29