### PR TITLE
Skip Tempest Tests not relevant to current environment

### DIFF
--- a/build_scripts/test.sh
+++ b/build_scripts/test.sh
@@ -4,4 +4,4 @@
 
 python -m jiocloud.apply_resources ssh_config --project_tag=${project_tag} ${mappings_arg} environment/${layout:-full}.yaml > ssh_config
 
-ssh -F ssh_config -l ${ssh_user:-jenkins} gcp1_${project_tag} '~jenkins/tempest/run_tempest.sh -N' || true
+ssh -F ssh_config -l ${ssh_user:-jenkins} gcp1_${project_tag} '~jenkins/tempest/run_tempest.sh -N "tempest\.*(?!(.*thirdparty)|(.*baremetal)|(.*data_processing)|(.*messaging)|(.*orchestration)|(.*vpnaas)|(.*test_metering)|(.*cli)|(.*test_load_balancer)|(.*fwaas))"' || true


### PR DESCRIPTION
We can skip tempest tests which aren't currently relevant for our environment. This would limit failures to reflect only those components which we care about "at the moment".
The tests have been skipped through the below negative lookahead regex: 
./run_tempest.sh -N 'tempest\.*(?!(.*thirdparty)|(.*baremetal)|(.*data_processing)|(.*messaging)|(.*orchestration)|(.*vpnaas)|(.*test_metering)|(.*cli)|(.*test_load_balancer)|(.*fwaas))'

This can be modified to include/exclude more tests as and when more components are enabled in our environment. 