### PR TITLE
Set private interface to vhost0_or_eth0 for vagrant

### DIFF
--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -1,6 +1,6 @@
 public_address: "%{ipaddress_eth1}"
 public_interface: eth1
-private_address: "%{ipaddress_eth1}"
+private_address: "%{ipaddress_vhost0_or_eth1}"
 private_interface: eth1
 
 rjil::ceph::osd::autogenerate: true


### PR DESCRIPTION
so that compute hosts will work after the contrail
vrouter module switches the address to the other
interface.