### PR TITLE
Install jiocloud-ssl-certificate package on all machines

### DIFF
--- a/manifests/trust_selfsigned_cert.pp
+++ b/manifests/trust_selfsigned_cert.pp
@@ -3,8 +3,14 @@
 #
 
 class rjil::trust_selfsigned_cert(
-  $cert = "/etc/ssl/certs/jiocloud.com.crt"
+  $cert             = '/etc/ssl/certs/jiocloud.com.crt',
+  $ssl_cert_package = 'jiocloud-ssl-certificate',
 ) {
+
+  ##
+  # jiocloud-ssl-certificate to be installed on all servers
+  ##
+  ensure_packages($ssl_cert_package)
 
   ##
   # Trust this self signed certificate, without this code openstack clients
@@ -17,7 +23,7 @@ class rjil::trust_selfsigned_cert(
   file { '/usr/local/share/ca-certificates/selfsigned.crt':
     ensure  => link,
     source  => $cert,
-    require => Package['ca-certificates'],
+    require => [Package['ca-certificates'],Package[$ssl_cert_package]],
     notify  => Exec['update-cacerts'],
   }
 


### PR DESCRIPTION
This patch install jiocloud-ssl-certificate package on all machines as part of
trust_selfsigned_cert.

In order to connect to the api endpoints (without insecure option), all machines
need to trust selfsigned certificate.

This should fix puppet failures on some nodes (like etcd) on vagrant
environment.