### PR TITLE
Add killall 0 check

### DIFF
--- a/files/tests/nagios_killall_0
+++ b/files/tests/nagios_killall_0
@@ -1,0 +1,22 @@
+#
+# Nagios check that uses killall -0 to reliably determine if
+# a given process is running. This is written to replace
+# check_procs, which does not work well because of column
+# limits of ps
+#
+if [ -z "$1" ]
+then
+  echo "Must pass process name"
+  exit 3
+fi
+
+killall -0 $1
+
+ret_code=$?
+if [[ $ret_code = 1 ]]; then
+  echo "Process ${1} is not running"
+  exit 2
+else
+  echo "Process ${1} is running!"
+  exit $ret_code
+fi

--- a/manifests/test/base.pp
+++ b/manifests/test/base.pp
@@ -1,7 +1,9 @@
 #
 # Base class that sets up tests
 #
-class rjil::test::base {
+class rjil::test::base(
+  $nagios_base_dir = '/usr/lib/nagios/plugins',
+) {
 
   File {
     owner => 'root',
@@ -18,6 +20,12 @@ class rjil::test::base {
 
   file { '/usr/lib/jiocloud/tests':
     ensure => directory,
+  }
+
+  # Add a custom nagios check for killall -0
+  file { "${nagios_base_dir}/check_killall_0":
+    source => 'puppet:///modules/rjil/tests/nagios_killall_0',
+    mode   => '0755',
   }
 
 }


### PR DESCRIPTION
nagios check for check_procs is awful. It has
a system dependency on COLUMNS b/c of the
way that it invokes ps that makes it surprisingly
unusable.

this patch adds a check based on killall -0 that
actually can be used to check processes.