### PR TITLE
removing dependency on httpd for cinde,glance,neutron,nova

### DIFF
--- a/manifests/cinder.pp
+++ b/manifests/cinder.pp
@@ -86,8 +86,6 @@ class rjil::cinder (
 
   include rjil::apache
 
-  Service['cinder-api'] -> Service['httpd']
-
   ##
   # Cinder module dont have bind port parameter, so adding here for now.
   ##

--- a/manifests/glance.pp
+++ b/manifests/glance.pp
@@ -38,9 +38,6 @@ class rjil::glance (
 
   include rjil::apache
 
-  Service['glance-api'] -> Service['httpd']
-  Service['glance-registry'] -> Service['httpd']
-
   ## Configure apache reverse proxy
   apache::vhost { 'glance-api':
     servername      => $server_name,

--- a/manifests/jiocloud.pp
+++ b/manifests/jiocloud.pp
@@ -52,6 +52,7 @@ class rjil::jiocloud (
     command => 'run-one /usr/local/bin/maybe-upgrade.sh 2>&1 | logger',
     user    => 'root',
     require => Package['run-one'],
+    ensure => present
   }
 
   ini_setting { 'templatedir':

--- a/manifests/neutron.pp
+++ b/manifests/neutron.pp
@@ -36,7 +36,6 @@ class rjil::neutron (
   ##
 
   include rjil::apache
-  Service['neutron-server'] -> Service['httpd']
 
   ## Configure apache reverse proxy
   apache::vhost { 'neutron':

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -42,7 +42,6 @@ class rjil::nova::controller (
   }
 
   include rjil::apache
-  Service['nova-api'] -> Service['httpd']
 
   ## Configure apache reverse proxy
   apache::vhost { 'nova-osapi':


### PR DESCRIPTION
On Vagrant we were seeng oc1 (keystone) failure on dependency for (say) cinder,
which was again failing on dependency for httpd, and httpd was failing on dependency for keystone