### PR TITLE
preserve consul_discovery_token across failures

### DIFF
--- a/vagrant_parallel_provision.sh
+++ b/vagrant_parallel_provision.sh
@@ -8,7 +8,12 @@ up() {
 
 provision() {
   sleep 5
-  . newtokens.sh
+  if [ -z "$consul_discovery_token" ]
+  then
+	echo "We are going ahead and using the old token, if you *want to use new token* unset $consul_discovery_token"
+  else
+  	. newtokens.sh
+  fi
   if [ ! -n $consul_discovery_token ]; then
     echo "Error fetching consul discovery token, exiting"
     exit 100


### PR DESCRIPTION
This came up twice, hence making a change -
./vagrant_parallel_provision.sh up
after which 'consul members' shows -
Node          Address              Status  Type    Build  Protocol
stmonleader1  192.168.200.8:8301   alive   client  0.4.0  2
ct1           192.168.200.7:8301   alive   client  0.4.0  2
etcd1         192.168.200.3:8301   alive   server  0.4.0  2
cp1           192.168.200.11:8301  alive   client  0.4.0  2
haproxy1      192.168.200.4:8301   alive   client  0.4.0  2
cp2           192.168.200.12:8301  alive   client  0.4.0  2
gcp1          192.168.200.13:8301  alive   client  0.4.0  2
ocdb1         192.168.200.6:8301   alive   client  0.4.0  2

stmon{1,2} did not register, however vagrant status shows all up..
sanjayu@cmpt:~/workspace/t1$ vagrant status
Current machine states:

etcd1                     running (virtualbox)
haproxy1                  running (virtualbox)
oc1                       running (virtualbox)
ocdb1                     running (virtualbox)
ct1                       running (virtualbox)
stmonleader1              running (virtualbox)
stmon1                    running (virtualbox)
stmon2                    running (virtualbox)
cp1                       running (virtualbox)
cp2                       running (virtualbox)
gcp1                      running (virtualbox)

this is strange!