### PR TITLE
Add datacenter for consul builds

### DIFF
--- a/manifests/jiocloud/consul/agent.pp
+++ b/manifests/jiocloud/consul/agent.pp
@@ -11,10 +11,10 @@ class rjil::jiocloud::consul::agent(
     config_hash => {
       'bind_addr'        => $bind_addr,
       'start_join'       => [$join_address],
-      'datacenter'       => "$::env",
       'data_dir'         => '/var/lib/consul-jio',
       'log_level'        => 'INFO',
       'server'           => false,
+      'datacenter'       => $::consul_discovery_token,
     }
   }
 }

--- a/manifests/jiocloud/consul/bootstrapserver.pp
+++ b/manifests/jiocloud/consul/bootstrapserver.pp
@@ -5,11 +5,11 @@ class rjil::jiocloud::consul::bootstrapserver(
   class { 'rjil::jiocloud::consul':
     config_hash => {
       'bind_addr'        => $bind_addr,
-      'datacenter'       => "$::env",
       'data_dir'         => '/var/lib/consul-jio',
       'log_level'        => 'INFO',
       'server'           => true,
       'bootstrap_expect' => $bootstrap_expect + 0,
+      'datacenter'       => $::consul_discovery_token,
     }
   }
 }

--- a/manifests/jiocloud/consul/server.pp
+++ b/manifests/jiocloud/consul/server.pp
@@ -11,10 +11,10 @@ class rjil::jiocloud::consul::server(
     config_hash => {
       'bind_addr'        => $bind_addr,
       'start_join'       => [$join_address],
-      'datacenter'       => "$::env",
       'data_dir'         => '/var/lib/consul-jio',
       'log_level'        => 'INFO',
       'server'           => true,
+      'datacenter'       => $::consul_discovery_token,
     }
   }
 }

--- a/manifests/service_blocker.pp
+++ b/manifests/service_blocker.pp
@@ -14,7 +14,7 @@
 define rjil::service_blocker(
   $tries      = 30,
   $try_sleep  = 20,
-  $datacenter = $::env,
+  $datacenter = $::consul_discovery_token,
 ) {
 
   $service_hostname = "${name}.service.${datacenter}.consul"

--- a/spec/classes/consul_spec.rb
+++ b/spec/classes/consul_spec.rb
@@ -22,10 +22,11 @@ describe 'rjil::jiocloud::consul::bootstrapserver' do
   let :facts  do
     {
       :env             => 'testenv',
-	    :osfamily        => 'Debian',
-	    :operatingsystem => 'Ubuntu',
-	    :architecture    => 'x86_64',
-	    :lsbdistrelease  => '14.04'
+      :osfamily        => 'Debian',
+      :operatingsystem => 'Ubuntu',
+      :architecture    => 'x86_64',
+      :lsbdistrelease  => '14.04',
+      :consul_discovery_token => 'token'
     }
   end
 
@@ -34,11 +35,11 @@ describe 'rjil::jiocloud::consul::bootstrapserver' do
       should contain_class('rjil::jiocloud::consul').with({
         'config_hash' => {
           'bind_addr'        => '0.0.0.0',
-          'datacenter'       => 'testenv',
           'data_dir'         => '/var/lib/consul-jio',
           'log_level'        => 'INFO',
           'server'           => true,
-          'bootstrap_expect' => 1
+          'bootstrap_expect' => 1,
+          'datacenter'       => 'token'
         }
       })
     end
@@ -63,10 +64,10 @@ describe 'rjil::jiocloud::consul::server' do
         'config_hash' => {
           'bind_addr'        => '0.0.0.0',
           'start_join'       => ['testtoken.service.consuldiscovery.linux2go.dk'],
-          'datacenter'       => 'testenv',
           'data_dir'         => '/var/lib/consul-jio',
           'log_level'        => 'INFO',
           'server'           => true,
+          'datacenter'       => 'testtoken'
         }
       })
     end
@@ -91,10 +92,10 @@ describe 'rjil::jiocloud::consul::agent' do
         'config_hash' => {
           'bind_addr'        => '0.0.0.0',
           'start_join'       => ['testtoken.service.consuldiscovery.linux2go.dk'],
-          'datacenter'       => 'testenv',
           'data_dir'         => '/var/lib/consul-jio',
           'log_level'        => 'INFO',
           'server'           => false,
+          'datacenter'       => 'testtoken'
         }
       })
     end


### PR DESCRIPTION
Since we are deploying multiple consul instances
into the same subdomain, it is possible that
the bootstrap servers might use gossip to build
a mega-cluster.

We could not figure out exactly how this was possible,
but we feel confident that this patch will resolve it.