### PR TITLE
Use 'storage' instance type for storage nodes

### DIFF
--- a/environment/full.yaml
+++ b/environment/full.yaml
@@ -28,12 +28,12 @@ resources:
     networks: default
   stmonleader:
     number: 1
-    flavor: large
+    flavor: storage
     image: trusty
     networks: default
   stmon:
     number: 2
-    flavor: large
+    flavor: storage
     image: trusty
     networks: default
   cp:

--- a/environment/hp.map.yaml
+++ b/environment/hp.map.yaml
@@ -4,6 +4,7 @@ flavor:
   small: 100
   medium: 101
   large: 102
+  storage: 102
 networks:
    default:
      - d7c83218-276b-4e4c-8ed1-1165b44c3a44

--- a/environment/jio_staging.map.yaml
+++ b/environment/jio_staging.map.yaml
@@ -4,6 +4,7 @@ flavor:
   small: 2
   medium: 2
   large: 3
+  storage: 3
 networks:
   default:
     - 707e1858-4aff-456f-8a1f-3c8f6e00dd12

--- a/environment/vagrant-vbox.map.yaml
+++ b/environment/vagrant-vbox.map.yaml
@@ -13,3 +13,6 @@ flavor:
   large:
     ram: 4096
     cpu: 2
+  storage:
+    ram: 4096
+    cpu: 2


### PR DESCRIPTION
This is needed for baremetal deployment since we want to make sure the right
type of servers are used for storage.