### PR TITLE
Removed service blocker to avoid unneccessary wait

### DIFF
--- a/manifests/keystone.pp
+++ b/manifests/keystone.pp
@@ -19,6 +19,8 @@ class rjil::keystone(
   $disable_db_sync        = false,
 ) {
 
+  Service['keystone'] -> Service['httpd']
+
   if $public_address == '0.0.0.0' {
     $address = '127.0.0.1'
   } else {

--- a/site.pp
+++ b/site.pp
@@ -109,11 +109,6 @@ node /^ocdb\d+/ {
   include rjil::openstack_zeromq
   include openstack_extras::keystone_endpoints
   include rjil::keystone::test_user
-  # ensure that we don't create keystone objects until
-  # the service is operational
-  ensure_resource('rjil::service_blocker', 'keystone-admin', {})
-  Rjil::Service_blocker['keystone-admin'] -> Class['openstack_extras::keystone_endpoints']
-  Rjil::Service_blocker['keystone-admin'] -> Class['rjil::keystone::test_user']
 }
 
 #


### PR DESCRIPTION
* Removed service blocker before keystone objects
* Added dependancy on http for keystone

This should result a working openstack cluster in vagrant. It may need further
optimization, but this should work for now.