### PR TITLE
remove unused hierarchies

### DIFF
--- a/hiera/hiera.yaml
+++ b/hiera/hiera.yaml
@@ -6,8 +6,6 @@
   :datadir: /etc/puppet/hiera/data
 :hierarchy:
   - "clientcert/%{::clientcert}"
-  - user
-  - services
   - "secrets/%{env}"
   - "role/%{jiocloud_role}"
   - "cloud_provider/%{cloud_provider}"


### PR DESCRIPTION
the user and services level for hiera
are not actually being used for anything.

This commit removes those unused levels
to simplify hiera.