### PR TITLE
Install molly-guard everywhere

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -17,6 +17,8 @@ class rjil::system(
   include rjil::system::apt
   include rjil::system::accounts
 
+  ensure_packages(['molly-guard'])
+
   ## Setup tests
   rjil::test {'check_timezone.sh':}
 

--- a/spec/classes/system_spec.rb
+++ b/spec/classes/system_spec.rb
@@ -34,6 +34,7 @@ describe 'rjil::system' do
       should contain_class('timezone')
       should contain_class('rjil::system::apt')
       should contain_class('rjil::system::accounts')
+      should contain_package('molly-guard')
     end
   end
 end


### PR DESCRIPTION
molly-guard prevents you from shutting down or rebooting the wrong
system by asking you to confirm the name of the system you think you're
shutting down or rebooting before it runs the actual command.