### PR TITLE
Refactor of consul service checks

### DIFF
--- a/files/tests/cinder-backup.sh
+++ b/files/tests/cinder-backup.sh
@@ -3,6 +3,7 @@ set -e
 if [ -f /root/openrc ]; then
   source /root/openrc
   cinder backup-list
+  sudo cinder-manage service list | grep "cinder-backup.*$(hostname).*enabled.*:-)"
 else
   echo "Critical: Openrc doesn't exist"
   exit 2

--- a/manifests/cinder.pp
+++ b/manifests/cinder.pp
@@ -83,7 +83,6 @@ class rjil::cinder (
   Class['rjil::ceph::mon_config'] ->
   Class['::cinder::volume']
 
-
   include rjil::apache
 
   Service['cinder-api'] -> Service['httpd']
@@ -225,19 +224,22 @@ class rjil::cinder (
     port          => $public_port,
   }
 
-  rjil::jiocloud::consul::service { 'cinder-volume':
-    port          => 0,
-    check_command => '/usr/lib/nagios/plugins/check_procs -c 1:10 -C cinder-volume'
+  rjil::test::check { 'cinder-volume':
+    type => 'proc',
   }
 
-  rjil::jiocloud::consul::service { 'cinder-scheduler':
-    port          => 0,
-    check_command => "sudo cinder-manage service list | grep 'cinder-scheduler.*${::hostname}.*enabled.*:-)'"
+  rjil::jiocloud::consul::service { 'cinder-volume': }
+
+  rjil::test::check { 'cinder-scheduler':
+    type => 'proc',
   }
 
-  rjil::jiocloud::consul::service { 'cinder-backup':
-    port          => 0,
-    check_command => "sudo cinder-manage service list | grep 'cinder-backup.*${::hostname}.*enabled.*:-)'"
+  rjil::jiocloud::consul::service { 'cinder-scheduler': }
+
+  rjil::test::check { 'cinder-backup':
+    type => 'proc',
   }
+
+  rjil::jiocloud::consul::service { 'cinder-backup': }
 
 }

--- a/manifests/glance.pp
+++ b/manifests/glance.pp
@@ -104,8 +104,16 @@ class rjil::glance (
     fail("Unsupported backend ${backend}")
   }
 
+  rjil::test::check { 'glance':
+    type    => 'http',
+    address => $server_name,
+    port    => $api_public_port,
+    ssl     => $ssl,
+  }
+
   rjil::jiocloud::consul::service { "glance":
     tags          => ['real'],
     port          => $::glance::api::bind_port,
   }
+
 }

--- a/manifests/jiocloud/consul/service.pp
+++ b/manifests/jiocloud/consul/service.pp
@@ -1,6 +1,6 @@
 define rjil::jiocloud::consul::service(
-  $port,
-  $check_command = "/usr/lib/jiocloud/tests/${name}.sh",
+  $port          = 0,
+  $check_command = "/usr/lib/jiocloud/tests/service_checks/${name}.sh",
   $interval      = '10s',
   $tags          = [],
 ) {

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -183,28 +183,36 @@ class rjil::nova::controller (
     interval      => $consul_check_interval,
   }
 
+  rjil::test::check { 'nova-scheduler':
+    type => 'proc',
+  }
+
   rjil::jiocloud::consul::service {'nova-scheduler':
-    port          => 0,
-    check_command => "sudo nova-manage service list | grep 'nova-scheduler.*${::hostname}.*enabled.*:-)'",
     interval      => $consul_check_interval,
+  }
+
+  rjil::test::check { 'nova-conductor':
+    type => 'proc',
   }
 
   rjil::jiocloud::consul::service {'nova-conductor':
-    port          => 0,
     interval      => $consul_check_interval,
-    check_command => "sudo nova-manage service list | grep 'nova-conductor.*${::hostname}.*enabled.*:-)'"
   }
 
-  rjil::jiocloud::consul::service {'nova-cert':
-    port          => 0,
-    interval      => $consul_check_interval,
-    check_command => "sudo nova-manage service list | grep 'nova-cert.*${::hostname}.*enabled.*:-)'"
+  rjil::test::check { 'nova-cert':
+    type => 'proc',
   }
 
-  rjil::jiocloud::consul::service {'nova-consoleauth':
-    port          => 0,
+  rjil::jiocloud::consul::service { 'nova-cert':
     interval      => $consul_check_interval,
-    check_command => "sudo nova-manage service list | grep 'nova-consoleauth.*${::hostname}.*enabled.*:-)'"
+  }
+
+  rjil::test::check { 'nova-consoleauth':
+    type => 'proc',
+  }
+
+  rjil::jiocloud::consul::service { 'nova-consoleauth':
+    interval      => $consul_check_interval,
   }
 
   rjil::jiocloud::consul::service {'nova-vncproxy':

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -18,7 +18,7 @@
 #
 class rjil::nova::controller (
   $vncproxy_bind_port   = 6080,
-  $consul_check_interval= '120s',
+  $consul_check_interval= '10s',
   $default_floating_pool = 'public',
   $memcached_servers    = service_discover_dns('memcached.service.consul','ip'),
   $admin_email          = 'root@localhost',

--- a/manifests/test/base.pp
+++ b/manifests/test/base.pp
@@ -22,6 +22,10 @@ class rjil::test::base(
     ensure => directory,
   }
 
+  file { '/usr/lib/jiocloud/tests/service_checks':
+    ensure => 'directory',
+  }
+
   # Add a custom nagios check for killall -0
   file { "${nagios_base_dir}/check_killall_0":
     source => 'puppet:///modules/rjil/tests/nagios_killall_0',

--- a/manifests/test/check.pp
+++ b/manifests/test/check.pp
@@ -4,7 +4,7 @@
 #
 
 define rjil::test::check(
-  $port,
+  $port    = 0,
   $address = '127.0.0.1',
   $ssl     = false,
   $type    = 'http',
@@ -12,7 +12,7 @@ define rjil::test::check(
 
   include rjil::test::base
 
-  file { "/usr/lib/jiocloud/tests/${name}.sh":
+  file { "/usr/lib/jiocloud/tests/service_checks/${name}.sh":
     content => template("rjil/tests/${type}_check.sh.erb"),
     owner   => 'root',
     group   => 'root',

--- a/spec/classes/ceph/radosgw_spec.rb
+++ b/spec/classes/ceph/radosgw_spec.rb
@@ -33,15 +33,15 @@ describe 'rjil::ceph::radosgw' do
 
       should contain_package('python-swiftclient')
 
-      should contain_file('/usr/lib/jiocloud/tests/ceph_radosgw.sh')
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/radosgw.sh')
 
       should contain_rjil__jiocloud__consul__service('radosgw').with({
         'tags'          => ['real'],
         'port'          => '80',
-        'check_command' => '/usr/lib/jiocloud/tests/radosgw.sh',
+        'check_command' => '/usr/lib/jiocloud/tests/service_checks/radosgw.sh',
       })
 
-      should contain_file('/usr/lib/jiocloud/tests/radosgw.sh').with_content(/check_http -H 127\.0\.0\.1 -p 80/)
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/radosgw.sh').with_content(/check_http -H 127\.0\.0\.1 -p 80/)
 
     end
   end
@@ -50,7 +50,7 @@ describe 'rjil::ceph::radosgw' do
     let :params do
       {'ssl' => true}
     end
-    it { should contain_file('/usr/lib/jiocloud/tests/radosgw.sh').with_content(/check_http -S -H 127\.0\.0\.1 -p 80/) }
+    it { should contain_file('/usr/lib/jiocloud/tests/service_checks/radosgw.sh').with_content(/check_http -S -H 127\.0\.0\.1 -p 80/) }
   end
 
 end

--- a/spec/classes/cinder_spec.rb
+++ b/spec/classes/cinder_spec.rb
@@ -39,7 +39,7 @@ describe 'rjil::cinder' do
       should contain_file('/usr/lib/jiocloud/tests/cinder-api.sh')
       should contain_file('/usr/lib/jiocloud/tests/cinder-volume.sh')
       should contain_file('/usr/lib/jiocloud/tests/cinder-scheduler.sh')
-      should contain_file('/usr/lib/jiocloud/tests/cinder.sh').with_content(
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/cinder.sh').with_content(
         /check_http -H 10\.1\.1\.1 -p 8776/
       )
       should contain_Cinder_config('database/connection').that_requires('Rjil::Service_blocker[mysql]')
@@ -84,15 +84,15 @@ describe 'rjil::cinder' do
       should contain_rjil__jiocloud__consul__service('cinder').with({
         'tags'          => ['real'],
         'port'          => 8776,
-        'check_command' => "/usr/lib/jiocloud/tests/cinder.sh"
+        'check_command' => "/usr/lib/jiocloud/tests/service_checks/cinder.sh"
       })
       should contain_rjil__jiocloud__consul__service('cinder-volume').with({
         'port'          => 0,
-        'check_command' => "/usr/lib/nagios/plugins/check_procs -c 1:10 -C cinder-volume"
+        'check_command' => "/usr/lib/jiocloud/tests/service_checks/cinder-volume.sh"
       })
       should contain_rjil__jiocloud__consul__service('cinder-scheduler').with({
         'port'          => 0,
-        'check_command' => "sudo cinder-manage service list | grep 'cinder-scheduler.*node1.*enabled.*:-)'"
+        'check_command' => "/usr/lib/jiocloud/tests/service_checks/cinder-scheduler.sh"
       })
     end
   end
@@ -102,7 +102,7 @@ describe 'rjil::cinder' do
     end
     it do
       should contain_apache__vhost('cinder').with_ssl(true)
-      should contain_file('/usr/lib/jiocloud/tests/cinder.sh').with_content(
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/cinder.sh').with_content(
         /check_http -S -H 10\.1\.1\.1 -p 8776/
       )
     end

--- a/spec/classes/keystone_spec.rb
+++ b/spec/classes/keystone_spec.rb
@@ -28,8 +28,8 @@ describe 'rjil::keystone' do
 
   describe 'default resources' do
     it 'should contain default resources' do
-      should contain_file('/usr/lib/jiocloud/tests/keystone.sh').with_content(/check_http -H 127\.0\.0\.1 -p 443/)
-      should contain_file('/usr/lib/jiocloud/tests/keystone-admin.sh').with_content(/check_http -H 127\.0\.0\.1 -p 35357/)
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/keystone.sh').with_content(/check_http -H 127\.0\.0\.1 -p 443/)
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/keystone-admin.sh').with_content(/check_http -H 127\.0\.0\.1 -p 35357/)
       should contain_class('keystone')
     end
   end

--- a/spec/classes/neutron_spec.rb
+++ b/spec/classes/neutron_spec.rb
@@ -32,7 +32,7 @@ describe 'rjil::neutron' do
 
   context 'with defaults' do
     it  do
-      should contain_file('/usr/lib/jiocloud/tests/neutron.sh').with_content(
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/neutron.sh').with_content(
         /check_http -H 127\.0\.0\.1 -p 9696/
       )
       should contain_file('/usr/lib/jiocloud/tests/floating_ip.sh')
@@ -46,7 +46,7 @@ describe 'rjil::neutron' do
       should contain_rjil__jiocloud__consul__service('neutron').with({
         'tags'      => ['real'],
         'port'      => 9696,
-        'check_command' => "/usr/lib/jiocloud/tests/neutron.sh",
+        'check_command' => "/usr/lib/jiocloud/tests/service_checks/neutron.sh",
       })
 
       should contain_exec('empty_neutron_conf').with({
@@ -76,7 +76,7 @@ describe 'rjil::neutron' do
       {'ssl' => true}
     end
     it do
-      should contain_file('/usr/lib/jiocloud/tests/neutron.sh').with_content(
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/neutron.sh').with_content(
         /check_http -S -H 127\.0\.0\.1 -p 9696/
       )
       should contain_apache__vhost('neutron').with_ssl(true)

--- a/spec/classes/nova/controller_spec.rb
+++ b/spec/classes/nova/controller_spec.rb
@@ -102,23 +102,23 @@ describe 'rjil::nova::controller' do
       should contain_rjil__jiocloud__consul__service('nova').with({
         'tags'          => ['real'],
         'port'          => 100,
-        'check_command' => "/usr/lib/jiocloud/tests/nova.sh"
+        'check_command' => "/usr/lib/jiocloud/tests/service_checks/nova.sh"
       })
       should contain_rjil__jiocloud__consul__service('nova-scheduler').with({
         'port'          => 0,
-        'check_command' => "sudo nova-manage service list | grep 'nova-scheduler.*node1.*enabled.*:-)'"
+        'check_command' => '/usr/lib/jiocloud/tests/service_checks/nova-scheduler.sh'
       })
       should contain_rjil__jiocloud__consul__service('nova-conductor').with({
         'port'          => 0,
-        'check_command' => "sudo nova-manage service list | grep 'nova-conductor.*node1.*enabled.*:-)'"
+        'check_command' => '/usr/lib/jiocloud/tests/service_checks/nova-conductor.sh'
       })
       should contain_rjil__jiocloud__consul__service('nova-cert').with({
         'port'          => 0,
-        'check_command' => "sudo nova-manage service list | grep 'nova-cert.*node1.*enabled.*:-)'"
+        'check_command' => '/usr/lib/jiocloud/tests/service_checks/nova-cert.sh'
       })
       should contain_rjil__jiocloud__consul__service('nova-consoleauth').with({
         'port'          => 0,
-        'check_command' => "sudo nova-manage service list | grep 'nova-consoleauth.*node1.*enabled.*:-)'"
+        'check_command' => '/usr/lib/jiocloud/tests/service_checks/nova-consoleauth.sh'
       })
       should contain_rjil__jiocloud__consul__service('nova-vncproxy').with({
         'port'          => 101,

--- a/templates/tests/proc_check.sh.erb
+++ b/templates/tests/proc_check.sh.erb
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+sudo /usr/lib/nagios/plugins/check_killall_0 <%= @name %>


### PR DESCRIPTION
This refactor has the following goals:

- start the process of categorizing test
  types by putting service checks into
  their own directory.
- simplify service checks to do either
  process,tcp, or http validation.

It does the following:

- ensures that service checks do not rely
  on *-manage calls (this ensures that service
  checks do not wind up having external dependencies).
  These checks are modified to instead use process
  checks.
- ensures all changed service checks still exist as validation
  checks.
- moves service checks to their own directory
- sets 0 as default port for consul services
- adds explicit http service checks for glance