### PR TITLE
default map to environment var from vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
   # cloud file that is used
   environment = ENV['env'] || 'vagrant-vbox'
   layout = ENV['layout'] || 'full'
-  map = ENV['map'] || ENV['env']
+  map = ENV['map'] || environment
 
   config.vm.provider :virtualbox do |vb, override|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]


### PR DESCRIPTION
to fix a behavior change introduced in b51e24ccebdd71
which makes setting an ENV mandatory when a map is
not provided.