### PR TITLE
Add Glance Registry to the Consul Service

### DIFF
--- a/manifests/glance.pp
+++ b/manifests/glance.pp
@@ -111,9 +111,20 @@ class rjil::glance (
     ssl     => $ssl,
   }
 
+  rjil::test::check { 'glance-registry':
+    type    => 'tcp',
+    address => $registry_localbind_host,
+    port    => $registry_localbind_port,
+  }
+
   rjil::jiocloud::consul::service { "glance":
     tags          => ['real'],
     port          => $::glance::api::bind_port,
+  }
+
+  rjil::jiocloud::consul::service { 'glance-registry':
+    tags          => ['real'],
+    port          => $::glance::registry::bind_port,
   }
 
 }

--- a/manifests/test/glance.pp
+++ b/manifests/test/glance.pp
@@ -21,11 +21,4 @@ class rjil::test::glance(
     ensure => absent,
   }
 
-  file { "/usr/lib/jiocloud/tests/glance-registry.sh":
-    source => "puppet:///modules/rjil/tests/glance-registry.sh",
-    owner  => 'root',
-    group  => 'root',
-    mode   => '755',
-  }
-
 }

--- a/spec/classes/glance_spec.rb
+++ b/spec/classes/glance_spec.rb
@@ -35,7 +35,7 @@ describe 'rjil::glance' do
   context 'with http, File backend' do
     it 'should contain http with file backend' do
       should contain_file('/usr/lib/jiocloud/tests/glance.sh')
-      should contain_file('/usr/lib/jiocloud/tests/glance-registry.sh')
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/glance-registry.sh')
       should contain_class('rjil::apache')
 
       should contain_apache__vhost('glance-api').with(


### PR DESCRIPTION
This patch lists the Glance Registry with the Consul Service and also
configures basic local validation checks for Glance Registry.
This would resolve #358 