### PR TITLE
Add a hwprofile layer to hiera

### DIFF
--- a/hiera/hiera.yaml
+++ b/hiera/hiera.yaml
@@ -10,6 +10,7 @@
   - services
   - "secrets/%{env}"
   - "role/%{jiocloud_role}"
+  - "hw/%{cloud_provider}/%{productname}"
   - "cloud_provider/%{cloud_provider}"
   - "env/%{env}"
   - "secrets/common"


### PR DESCRIPTION
In the new production environment, there are more than one server type.
This means there are different names for interfaces, so they need
different values for e.g. public_interface. Although there's some
correlation between server type and role, this is not reliable.
    
I'm hoping that the productname will be a sufficiently strong identifier
for these kinds of settings. If not, we'll have to revisit in the
future.
