### PR TITLE
Update Cinder configuration file to provide the https url for the glance

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -243,6 +243,8 @@ cinder::volume::rbd::rbd_user: cinder_volume
 cinder::volume::rbd::volume_tmp_dir: /tmp
 cinder::volume::rbd::rbd_secret_uuid: "%{hiera('cinder_rbd_secret_uuid')}"
 
+cinder::glance::glance_api_servers: "%{hiera('api_protocol')}://%{hiera('glance_public_address')}:%{hiera('glance_api_port')}"
+
 ########### Nova config
 ###################################
 rjil::nova::controller::osapi_public_port: "%{hiera('nova_osapi_port')}"
@@ -771,3 +773,5 @@ tempest::provision::password: "%{hiera('tempest::password')}"
 tempest::provision::admin_username: "%{hiera('tempest::admin_username')}"
 tempest::provision::admin_password: "%{hiera('tempest::admin_password')}"
 tempest::provision::networkname: "%{hiera('tempest::fixed_network_name')}"
+
+

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -242,7 +242,6 @@ cinder::volume::rbd::rbd_pool: volumes
 cinder::volume::rbd::rbd_user: cinder_volume
 cinder::volume::rbd::volume_tmp_dir: /tmp
 cinder::volume::rbd::rbd_secret_uuid: "%{hiera('cinder_rbd_secret_uuid')}"
-
 cinder::glance::glance_api_servers: "%{hiera('api_protocol')}://%{hiera('glance_public_address')}:%{hiera('glance_api_port')}"
 
 ########### Nova config
@@ -773,5 +772,3 @@ tempest::provision::password: "%{hiera('tempest::password')}"
 tempest::provision::admin_username: "%{hiera('tempest::admin_username')}"
 tempest::provision::admin_password: "%{hiera('tempest::admin_password')}"
 tempest::provision::networkname: "%{hiera('tempest::fixed_network_name')}"
-
-

--- a/manifests/cinder.pp
+++ b/manifests/cinder.pp
@@ -171,6 +171,7 @@ class rjil::cinder (
   include rjil::ceph::mon_config
   include ::cinder
   include ::cinder::api
+  include ::cinder::glance
   include ::cinder::scheduler
   include ::cinder::volume
   include ::cinder::volume::rbd


### PR DESCRIPTION
The patch updates the cinder configuration file to provide the https url for the glance api servers. 

It would fix the below issue:
https://github.com/JioCloud/puppet-rjil/issues/345