### PR TITLE
Do not use pip to install tempest-lib package

### DIFF
--- a/manifests/tempest.pp
+++ b/manifests/tempest.pp
@@ -93,6 +93,7 @@ class rjil::tempest (
     'git',
     'python-setuptools',
     'python-tempest',
+    'python-tempest-lib',
     'python-hacking',
     'python-sphinx',
     'python-subunit',
@@ -126,11 +127,6 @@ class rjil::tempest (
     'python-mox3',
     'subunit',
   ])
-
-  package {'tempest-lib':
-    ensure   => present,
-    provider => 'pip',
-  }
 
   Class ['::tempest::provision'] -> Class['::tempest']
   include ::tempest::provision


### PR DESCRIPTION
Stop using pip to install tempest-lib package. 
Switch to python-tempest-lib package from the repo.
Note: We need tempest-lib:0.1.0 to be able to run tempest tests.