### PR TITLE
Fix Puppet Deprecation Warnings

### DIFF
--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -71,8 +71,9 @@ if [ -n "${puppet_modules_source_repo}" ]; then
   mkdir -p /etc/puppet/modules.overrides/rjil
   cp -Rvf /tmp/rjil/* /etc/puppet/modules.overrides/rjil/
   time librarian-puppet install --puppetfile=/tmp/rjil/Puppetfile --path=/etc/puppet/modules.overrides
-  puppet apply -e "ini_setting { modulepath: path => \"/etc/puppet/puppet.conf\", section => main, setting => modulepath, value => \"/etc/puppet/modules.overrides:/etc/puppet/modules\" }"
-  puppet apply -e "ini_setting { manifestdir: path => \"/etc/puppet/puppet.conf\", section => main, setting => manifestdir, value => \"/etc/puppet/manifests.overrides\" }"
+  puppet apply -e "ini_setting { basemodulepath: path => \"/etc/puppet/puppet.conf\", section => main, setting => basemodulepath, value => \"/etc/puppet/modules.overrides:/etc/puppet/modules\" }"
+  puppet apply -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests.overrides/site.pp\" }"
+  puppet apply -e "ini_setting { disable_per_environment_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => disable_per_environment_manifest, value => \"true\" }"
 fi
 sudo mkdir -p /etc/facter/facts.d
 echo 'consul_discovery_token='${consul_discovery_token} > /etc/facter/facts.d/consul.txt
@@ -82,7 +83,7 @@ echo 'cloud_provider='${cloud_provider} > /etc/facter/facts.d/cloud_provider.txt
 while true
 do
     # first install all packages to make the build as fast as possible
-    puppet apply --detailed-exitcodes \`puppet config print manifestdir\`/site.pp --tags package
+    puppet apply --detailed-exitcodes \`puppet config print default_manifest\` --tags package
     ret_code_package=\$?
     # now perform base config
     (echo 'File<| title == "/etc/consul" |> { purge => false }'; echo 'include rjil::jiocloud' ) | puppet apply --detailed-exitcodes --debug

--- a/files/maybe-upgrade.sh
+++ b/files/maybe-upgrade.sh
@@ -14,7 +14,7 @@ rv=$?
 run_puppet() {
         # ensure that our service catalog hiera data is available
         # now run puppet
-        puppet apply --detailed-exitcodes --logdest=syslog `puppet config print manifestdir`/site.pp
+        puppet apply --detailed-exitcodes --logdest=syslog `puppet config print default_manifest`
         # publish the results of that run
         ret_code=$?
         python -m jiocloud.orchestrate update_own_status puppet $ret_code

--- a/manifests/jiocloud.pp
+++ b/manifests/jiocloud.pp
@@ -60,4 +60,19 @@ class rjil::jiocloud (
     section => 'main',
     setting => 'templatedir',
   }
+
+  ini_setting { 'modulepath':
+    ensure  => absent,
+    path    => "/etc/puppet/puppet.conf",
+    section => 'main',
+    setting => 'modulepath',
+  }
+
+  ini_setting { 'manifestdir':
+    ensure  => absent,
+    path    => "/etc/puppet/puppet.conf",
+    section => 'main',
+    setting => 'manifestdir',
+  }
+
 }

--- a/spec/classes/jiocloud_spec.rb
+++ b/spec/classes/jiocloud_spec.rb
@@ -39,5 +39,20 @@ describe 'rjil::jiocloud' do
       'section' => 'main',
       'setting' => 'templatedir',
     })}
+
+    it { should contain_ini_setting('modulepath').with({
+      'ensure'  => 'absent',
+      'path'    => '/etc/puppet/puppet.conf',
+      'section' => 'main',
+      'setting' => 'modulepath',
+    })}
+ 
+    it { should contain_ini_setting('manifestdir').with({
+      'ensure'  => 'absent',
+      'path'    => '/etc/puppet/puppet.conf',
+      'section' => 'main',
+      'setting' => 'manifestdir',
+    })}
+ 
   end
 end


### PR DESCRIPTION
Currently, every Puppet run throws two warnings saying that Puppet is
using `modulepath` and `manifestdir` which are deprecated. This is
primarily because Puppetlabs is moving towards the use of Directory
Environments.

This patch disables the default per environment manifests and sets up
globals for modules and manifests pointing to their corresponding
overrides directory.