### PR TITLE
Added options for allocation pools to allocate subset of IPs to a subnet

### DIFF
--- a/hiera/data/env/at.yaml
+++ b/hiera/data/env/at.yaml
@@ -8,8 +8,11 @@ rjil::ceph::osd::osd_journal_size: 2
 nova::compute::libvirt::libvirt_virt_type: qemu
 
 rjil::neutron::contrail::public_cidr: 100.1.0.0/24
+rjil::neutron::contrail::public_subnet_ip_start: 100.1.0.11
+rjil::neutron::contrail::public_subnet_ip_end: 100.1.0.254
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,vigneshvar,alokjani,amar,ynshenoy,hanish]
 rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,vigneshvar,alokjani,amar,ynshenoy,hanish]
+
 rjil::base::self_signed_cert: true
 
 tempest::admin_password: tempest_admin

--- a/hiera/data/env/gate.yaml
+++ b/hiera/data/env/gate.yaml
@@ -8,6 +8,8 @@ rjil::ceph::osd::osd_journal_size: 2
 nova::compute::libvirt::libvirt_virt_type: qemu
 
 rjil::neutron::contrail::public_cidr: 100.1.0.0/24
+rjil::neutron::contrail::public_subnet_ip_start: 100.1.0.11
+rjil::neutron::contrail::public_subnet_ip_start: 100.1.0.254
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet]
 rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet]
 rjil::base::self_signed_cert: true


### PR DESCRIPTION
There would be situations when set of IPs in the floating network provided need to be set aside for some purpose, so that they can be statically managed ( may be something like certain number of IPs to be added to physical network devices or something which cannot be managed with neutron.

This patch to support providing ip address range between which to allocate for floating pool.