### PR TITLE
rspec-pupept updated to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 group :development, :test do
   gem 'bodeco_module_helper', :git => 'https://github.com/bodeco/bodeco_module_helper.git', :ref => 'a0de65d'
+  gem 'rspec-puppet', '~>1.0'
   gem 'hiera-puppet-helper', :git => 'https://github.com/bobtfish/hiera-puppet-helper', :ref => '80b597aec1a'
   gem 'rspec-puppet-utils'
   gem 'mocha', '~>0.10.5'


### PR DESCRIPTION
it was causing our tests to fail. I would
have liked to make us compat with 2.0, but
we cannot until this issue is resolved:

https://github.com/rodjek/rspec-puppet/issues/253