### PR TITLE
Make sure default_manifest is always set

### DIFF
--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -72,6 +72,8 @@ if [ -n "${puppet_modules_source_repo}" ]; then
   puppet apply -e "ini_setting { basemodulepath: path => \"/etc/puppet/puppet.conf\", section => main, setting => basemodulepath, value => \"/etc/puppet/modules.overrides:/etc/puppet/modules\" }"
   puppet apply -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests.overrides/site.pp\" }"
   puppet apply -e "ini_setting { disable_per_environment_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => disable_per_environment_manifest, value => \"true\" }"
+else
+  puppet apply -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests/site.pp\" }"
 fi
 sudo mkdir -p /etc/facter/facts.d
 echo 'consul_discovery_token='${consul_discovery_token} > /etc/facter/facts.d/consul.txt

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -7,6 +7,7 @@ class rjil::base (
   include rjil::jiocloud
   include rjil::system
   include rjil::jiocloud::dns
+  include rjil::default_manifest
   ##
   # In case of self signed certificate mostly all of the servers need to trust
   # tht certificate as it is required to do api calls to any openstack services

--- a/manifests/default_manifest.pp
+++ b/manifests/default_manifest.pp
@@ -3,15 +3,15 @@
 #
 class rjil::default_manifest {
   if ($::settings::default_manifest == './manifests') {
-	$val = '/etc/puppet/manifests/site.pp'
+    $val = '/etc/puppet/manifests/site.pp'
   } else {
-	$val = "$::settings::default_manifest"
+    $val = $::settings::default_manifest
   }
 
-  ini_setting { default_manifest:
-    path    => "/etc/puppet/puppet.conf",
-	section => main,
-	setting => default_manifest,
-	value   => $val
+  ini_setting { 'default_manifest':
+    path    => '/etc/puppet/puppet.conf',
+    section => main,
+    setting => default_manifest,
+    value   => $val
   }
 }

--- a/manifests/default_manifest.pp
+++ b/manifests/default_manifest.pp
@@ -1,0 +1,17 @@
+#
+# Class rjil::default_manifest
+#
+class rjil::default_manifest {
+  if ($::settings::default_manifest == './manifests') {
+	$val = '/etc/puppet/manifests/site.pp'
+  } else {
+	$val = "$::settings::default_manifest"
+  }
+
+  ini_setting { default_manifest:
+    path    => "/etc/puppet/puppet.conf",
+	section => main,
+	setting => default_manifest,
+	value   => $val
+  }
+}


### PR DESCRIPTION
I.e.:
 * when we're testing a git branch
 * when we're not testing a git branch (acceptance tests)
 * when upgrading a live deployment