### PR TITLE
Ensure that nuetron haproxy definitions get added

### DIFF
--- a/templates/tests/haproxy_openstack.sh.erb
+++ b/templates/tests/haproxy_openstack.sh.erb
@@ -4,3 +4,4 @@ test -f /root/openrc
 source /root/openrc
 keystone catalog
 glance image-list
+neutron net-list


### PR DESCRIPTION
Currently, if haproxy validation before it is ready
to add the haproxy definitions, then it never gets
configured.

This patch adds a neutron check to the haproxy validation
to ensure that puppet keeps running until neutron works.