### PR TITLE
Retry on wget

### DIFF
--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -7,6 +7,22 @@ set -x
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
+
+function retry()
+{
+  local n=0
+  local try=\$1
+  local wait=\$2
+  local cmd="\${@: 3}"
+  until [[ \$n -ge \$try ]]; do
+    \$cmd && break || {
+      ((n++))
+      echo "Command Failed.. retry \$n ::"
+      sleep \$wait
+    }
+  done
+}
+
 export layout="${layout}"
 release="\$(lsb_release -cs)"
 if [ -n "${git_protocol}" ]; then
@@ -24,14 +40,14 @@ then
 	export https_proxy=${env_https_proxy}
 	echo https_proxy="'${env_https_proxy}'" >> /etc/environment
 fi
-wget -O puppet.deb -t 2 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
+retry 3 5 wget -O puppet.deb -t 2 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
 if [ "${env}" == "at" ]
 then
 	jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}-testing.deb
 else
 	jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}.deb
 fi
-wget -O jiocloud.deb -t 2 -T 30 \${jiocloud_repo_deb_url}
+retry 3 5 wget -O jiocloud.deb -t 2 -T 30 \${jiocloud_repo_deb_url}
 dpkg -i puppet.deb jiocloud.deb
 if http_proxy= wget -t 2 -T 30 -O internal.deb http://apt.internal.jiocloud.com/internal.deb
 then


### PR DESCRIPTION
Noticed good number of gate test failures because of temporary connection issues
to proxy node. So adding retry on wgets in userdata.

Also this patch add a retry function which can be reused.

This should fix #402 