### PR TITLE
Sleep long enough for cloud-init to have a chance to give up

### DIFF
--- a/build_scripts/deploy.sh
+++ b/build_scripts/deploy.sh
@@ -15,7 +15,7 @@ time python -m jiocloud.apply_resources apply ${EXTRA_APPLY_RESOURCES_OPTS} --ke
 # This is crazy, but it seems to help A LOT
 if [ "$cloud_provider" = 'hp' ]
 then
-    sleep 100
+    sleep 270
     nova list | grep test${BUILD_NUMBER} | cut -f2 -d' ' | while read uuid; do nova console-log $uuid | grep Giving.up.on.md && nova reboot $uuid || true; done
 fi
 


### PR DESCRIPTION
If DHCP fails, that'll take 2 minutes before the networking upstart
job gives up. Then another 2 minutes for cloud-init to give up reaching
the MD service. Add a buffer of an extra 30 seconds. That makes 270
seconds.