### PR TITLE
retry wget operations up to 5 times

### DIFF
--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -24,14 +24,14 @@ then
 	export https_proxy=${env_https_proxy}
 	echo https_proxy="'${env_https_proxy}'" >> /etc/environment
 fi
-wget -O puppet.deb -t 2 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
+wget -O puppet.deb -t 5 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
 if [ "${env}" == "at" ]
 then
 	jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}-testing.deb
 else
 	jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}.deb
 fi
-wget -O jiocloud.deb -t 2 -T 30 \${jiocloud_repo_deb_url}
+wget -O jiocloud.deb -t 5 -T 30 \${jiocloud_repo_deb_url}
 dpkg -i puppet.deb jiocloud.deb
 if http_proxy= wget -t 2 -T 30 -O internal.deb http://apt.internal.jiocloud.com/internal.deb
 then


### PR DESCRIPTION
to reduce spurious errors related to underlying
cloud network connectivity issues (specific to hp
cloud for this patch)