### PR TITLE
Nova flavor purge

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -111,7 +111,7 @@ mod 'stackforge/neutron',
 
 mod 'stackforge/nova',
   :git => "#{base_url}/hkumarmk/puppet-nova",
-  :ref => 'nova_flavor'
+  :ref => 'nova_flavor_purge'
 
 mod 'puppetlabs/rabbitmq',
   :git => "#{base_url}/puppetlabs/puppetlabs-rabbitmq",

--- a/Puppetfile
+++ b/Puppetfile
@@ -34,8 +34,8 @@ mod 'puppetlabs/vscrepo',
   :ref => '1.2.0'
 
 mod 'stackforge/tempest',
-  :git => "#{base_url}/jiocloud/puppet-tempest",
-  :ref => 'master'
+  :git => "#{base_url}/hkumarmk/puppet-tempest",
+  :ref => 'flavor_name'
 
 mod 'dprince/qpid',
   :git => "#{base_url}/dprince/puppet-qpid",

--- a/Puppetfile
+++ b/Puppetfile
@@ -78,8 +78,8 @@ mod 'stackforge/cinder',
   :ref => 'stable/icehouse'
 
 mod 'stackforge/openstacklib',
-  :git => "#{base_url}/stackforge/puppet-openstacklib",
-  :ref => 'master'
+  :git => "#{base_url}/hkumarmk/puppet-openstacklib",
+  :ref => 'removed_empty_element_from_args'
 
 mod 'stackforge/ironic',
   :git => "#{base_url}/JioCloud/puppet-ironic",
@@ -110,8 +110,8 @@ mod 'stackforge/neutron',
   :ref => 'stable/icehouse'
 
 mod 'stackforge/nova',
-  :git => "#{base_url}/sorenh/puppet-nova",
-  :ref => 'ironic'
+  :git => "#{base_url}/hkumarmk/puppet-nova",
+  :ref => 'nova_flavor'
 
 mod 'puppetlabs/rabbitmq',
   :git => "#{base_url}/puppetlabs/puppetlabs-rabbitmq",
@@ -126,7 +126,8 @@ mod 'stackforge/vswitch',
   :ref => '0.3.0'
 
 mod 'stackforge/openstack_extras',
-  :git => "#{base_url}/jiocloud/puppet-openstack_extras"
+  :git => "#{base_url}/hkumarmk/puppet-openstack_extras",
+  :ref => 'openstack_client'
 
 mod 'stackforge/heat',
   :git => "#{base_url}/stackforge/puppet-heat",

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -778,7 +778,7 @@ apache::default_ssl_key: '/etc/ssl/keys/jiocloud.com.key'
 tempest::tempest_repo_uri: 'https://github.com/JioCloud/tempest.git'
 tempest::image_name: cirros-0.3.3
 tempest::image_name_alt: cirros-0.3.3
-tempest::flavor_ref: 1
+tempest::flavor_name: small
 tempest::admin_password: tempest_admin
 tempest::admin_username: tempest_admin
 tempest::tenant_name: tempest

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -109,6 +109,10 @@ openstack_extras::auth_file::admin_password: "%{hiera('test_user_password')}"
 openstack_extras::auth_file::controller_node: "%{hiera('keystone_public_address')}"
 openstack_extras::auth_file::keystone_protocol: "%{hiera('api_protocol')}"
 
+########### client install
+##################################
+openstack_extras::client::ceilometer: false
+
 ########### Openstack ports
 ##################################
 localbind_host: 127.0.0.1
@@ -303,6 +307,29 @@ nova::compute::neutron::libvirt_vif_driver: nova_contrail_vif.contrailvif.VRoute
 rjil::nova::compute::cinder_rbd_secret_uuid: "%{hiera('cinder_rbd_secret_uuid')}"
 rjil::nova::compute::ceph_mon_key: "%{hiera('rjil::ceph::mon::key')}"
 
+rjil::nova::controller::nova_auth:
+  username: nova
+  password: "%{hiera('nova::keystone::auth::password')}"
+  tenant_name: services
+  auth_url: "%{hiera('rjil::keystone::protocol')}://%{hiera('nova::api::auth_host')}:%{hiera('keystone_port')}/%{hiera('rjil::keystone::version')}"
+
+rjil::nova::controller::flavors:
+  small:
+    ram: 1024
+    disk: 20
+    vcpu: 1
+  medium:
+    ram: 4096
+    disk: 40
+    vcpu: 2
+  large:
+    ram: 8192
+    disk: 40
+    vcpu: 4
+  xlarge:
+    ram: 16384
+    disk: 40
+    vcpu: 4
 
 ########### Ironic config
 ###################################

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -162,6 +162,13 @@ class rjil::nova::controller (
   create_resources('nova_flavor', $flavors, {auth => $nova_auth})
 
   ##
+  # Purge unmanaged flavors
+  ##
+  resources {'nova_flavor':
+    purge => true,
+  }
+
+  ##
   # Making sure /var/log/nova-manage.log is writable by nova user. This is
   # because, nova module is running "nova-manage db sync" as user nova
   # which is failing as nova dont have write permission to nova-manage.log.

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -30,6 +30,8 @@ class rjil::nova::controller (
   $osapi_localbind_port = 18774,
   $ec2_localbind_port   = 18773,
   $ssl                  = false,
+  $flavors              = {},
+  $nova_auth            = {},
 ) {
 
 # Tests
@@ -150,6 +152,11 @@ class rjil::nova::controller (
   include ::nova::consoleauth
   include ::nova::vncproxy
   include ::nova::quota
+
+  ##
+  # Create flavors
+  ##
+  create_resources('nova_flavor', $flavors, {auth => $nova_auth})
 
   ##
   # Making sure /var/log/nova-manage.log is writable by nova user. This is

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -36,6 +36,9 @@ class rjil::nova::controller (
 
 # Tests
   include rjil::test::nova_controller
+  class { 'rjil::test::nova_flavor':
+    flavors => $flavors,
+  }
 
   nova_config {
     'DEFAULT/default_floating_pool':      value => $default_floating_pool;

--- a/manifests/tempest.pp
+++ b/manifests/tempest.pp
@@ -11,6 +11,8 @@ class rjil::tempest (
   $neutron_admin_password = 'neutron',
   $glance_admin_user      = 'glance',
   $glance_admin_password  = 'glance',
+  $nova_admin_user        = 'nova',
+  $nova_admin_password    = 'nova',
   $tempest_test_file      = '/home/jenkins/tempest_tests.txt',
 ) {
 
@@ -41,6 +43,20 @@ class rjil::tempest (
   Keystone_config<||> -> Keystone_tenant<||>
   Keystone_config<||> -> Keystone_user<||>
   Keystone_config<||> -> Keystone_user_role<||>
+
+  ##
+  # nova config for nova_flavor
+  ##
+  Nova_config<||> -> Tempest_Config<||>
+  nova_config {
+    'keystone_authtoken/auth_host':         value => $auth_host;
+    'keystone_authtoken/auth_port':         value => $auth_port;
+    'keystone_authtoken/auth_uri':          value => "${auth_protocol}://${auth_host}:${auth_port}/v2.0";
+    'keystone_authtoken/auth_protocol':     value => $auth_protocol;
+    'keystone_authtoken/admin_tenant_name': value => $service_tenant;
+    'keystone_authtoken/admin_user':        value => $nova_admin_user;
+    'keystone_authtoken/admin_password':    value => $nova_admin_password;
+  }
 
   ##
   # Glance image and tempest glance image id setter need keystone section in

--- a/manifests/test/nova_flavor.pp
+++ b/manifests/test/nova_flavor.pp
@@ -8,6 +8,7 @@ class rjil::test::nova_flavor(
 ) {
 
   include rjil::test::base
+  include openstack_extras::auth_file
 
   file { "/usr/lib/jiocloud/tests/nova_flavor.sh":
     content => template("rjil/tests/nova_flavor.sh.erb"),

--- a/manifests/test/nova_flavor.pp
+++ b/manifests/test/nova_flavor.pp
@@ -1,0 +1,19 @@
+#
+# Class: rjil::test::nova_flavor
+#   Adding tests for nova flavor
+#
+
+class rjil::test::nova_flavor(
+  $flavors = []
+) {
+
+  include rjil::test::base
+
+  file { "/usr/lib/jiocloud/tests/nova_flavor.sh":
+    content => template("rjil/tests/nova_flavor.sh.erb"),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+  }
+
+}

--- a/site.pp
+++ b/site.pp
@@ -88,6 +88,7 @@ node /^oc\d+/ {
   include rjil::base
   include rjil::memcached
   include rjil::keystone
+  include openstack_extras::client
   include rjil::cinder
   include rjil::glance
   include rjil::openstack_zeromq
@@ -101,6 +102,7 @@ node /^oc\d+/ {
 node /^ocdb\d+/ {
   include rjil::base
   include rjil::memcached
+  include openstack_extras::client
   include rjil::db
   include rjil::keystone
   include rjil::cinder
@@ -122,6 +124,7 @@ node /^ocdb\d+/ {
 
 node /^oclb\d+/ {
   include rjil::base
+  include openstack_extras::client
   include rjil::memcached
   include rjil::db
   include rjil::keystone
@@ -145,6 +148,7 @@ node /^oclb\d+/ {
 node /^gcp\d+/ {
   include rjil::base
   include rjil::ceph
+  include openstack_extras::client
   include rjil::contrail::vrouter
   include rjil::openstack_zeromq
   include rjil::nova::compute
@@ -154,6 +158,7 @@ node /^gcp\d+/ {
 node /^cp\d+/ {
   include rjil::base
   include rjil::ceph
+  include openstack_extras::client
   include rjil::contrail::vrouter
   include rjil::openstack_zeromq
   include rjil::nova::compute
@@ -168,6 +173,7 @@ node /^haproxy\d+/ {
 node /^uc\d+/ {
   include rjil::base
   include rjil::memcached
+  include openstack_extras::client
   include rjil::db
   include rjil::keystone
   include rjil::glance

--- a/templates/tests/nova_flavor.sh.erb
+++ b/templates/tests/nova_flavor.sh.erb
@@ -1,0 +1,3 @@
+<% @flavors.each do |flavor| -%>
+openstack -q flavor show <%= flavor[0] %>
+<% end -%>

--- a/templates/tests/nova_flavor.sh.erb
+++ b/templates/tests/nova_flavor.sh.erb
@@ -1,3 +1,7 @@
+#!/bin/bash
+set -e
+test -f /root/openrc
+source /root/openrc
 <% @flavors.each do |flavor| -%>
 openstack -q flavor show <%= flavor[0] %>
 <% end -%>


### PR DESCRIPTION
* Create nova flavors
* Use flavor name for tempest
  * This need the patch jiocloud/puppet-tempest#9 to be merged
* Purge unmanaged nova flavors

This is a superset of PRs #401 and #396. The review and merge can be done on all individual PRs or only this PR.

Here are the dependant patches which need to be merged before this one.

* jiocloud/puppet-tempest#9
* JioCloud/puppet-nova#1
* JioCloud/puppet-nova#1
* JioCloud/puppet-openstack_extras#2
* JioCloud/puppet-openstacklib#1
