### PR TITLE
WIP: Cleanup Vagrant and make it use userdata.txt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,38 +58,13 @@ Vagrant.configure("2") do |config|
       config.vm.provision 'shell', :inline =>
          'cp /etc/puppet/hiera/hiera.yaml /etc/puppet'
 
-      config.vm.host_name = "#{node_name}.domain.name"
-      ['consul'].each do |x|
-        config.vm.provision 'shell', :inline =>
-          "[ -e '/etc/facter/facts.d/#{x}.txt' -o -n '#{ENV["#{x}_discovery_token"]}' ] || (echo 'No #{x} discovery token set. Bailing out. Use \". newtokens.sh\" to get tokens.' ; exit 1)"
-        config.vm.provision 'shell', :inline =>
-          "mkdir -p /etc/facter/facts.d; [ -e '/etc/facter/facts.d/#{x}.txt' ] && exit 0; echo #{x}_discovery_token=#{ENV["#{x}_discovery_token"]} > /etc/facter/facts.d/#{x}.txt"
-      end
+      #Install custom source.list (which can be local apt mirror)
+      #config.vm.provision 'shell', :inline =>
+      #'cp /etc/apt/sources.list /etc/apt/sources.list_arch_`date +%d%b%g_%H%M`;cp /etc/puppet/modules/rjil/files/sources.list /etc/apt/sources.list; apt-get update;echo "1st update..."'
 
-      config.vm.provision 'shell', :inline =>
-        "echo env=#{environment} > /etc/facter/facts.d/env.txt"
-
-      if ENV['http_proxy']
-        config.vm.provision 'shell', :inline =>
-        "echo \"Acquire::http { Proxy \\\"#{ENV['http_proxy']}\\\" }\" > /etc/apt/apt.conf.d/03proxy"
+      config.vm.provision 'shell' do |s|
+        s.inline = "export consul_discovery_token=#{ENV['consul_discovery_token']};export layout=#{layout};export map=#{map}; /etc/puppet/manifests/build_scripts/make_userdata.sh;bash -x ./userdata.txt"
       end
-
-      # run apt-get update and install pip
-      unless ENV['NO_APT_GET_UPDATE'] == 'true'
-        config.vm.provision 'shell', :inline =>
-        'apt-get update; apt-get install -y git curl;'
-      end
-
-      # upgrade puppet
-      if ENV['http_proxy']
-        config.vm.provision 'shell', :inline =>
-          "test -e puppet.deb && exit 0; release=$(lsb_release -cs);http_proxy=#{ENV['http_proxy']} wget -O puppet.deb http://apt.puppetlabs.com/puppetlabs-release-${release}.deb;dpkg -i puppet.deb;apt-get update;apt-get install -y puppet-common=3.6.2-1puppetlabs1"
-      else
-        config.vm.provision 'shell', :inline =>
-          "test -e puppet.deb && exit 0; release=$(lsb_release -cs);wget -O puppet.deb http://apt.puppetlabs.com/puppetlabs-release-${release}.deb;dpkg -i puppet.deb;apt-get update;apt-get install -y puppet-common=3.6.2-1puppetlabs1"
-      end
-      config.vm.provision 'shell', :inline =>
-        'puppet apply --detailed-exitcodes --debug -e "include rjil::jiocloud"; if [[ $? = 1 || $? = 4 || $? = 6 ]]; then apt-get update; puppet apply --detailed-exitcodes --debug -e "include rjil::jiocloud"; fi'
 
       net_prefix = ENV['NET_PREFIX'] || "192.168.100.0"
       config.vm.network "private_network", :type => :dhcp, :ip => net_prefix, :netmask => "255.255.255.0"

--- a/files/sources.list
+++ b/files/sources.list
@@ -1,0 +1,13 @@
+#Template file for sources.list
+##==============================
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty main restricted
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty-updates main restricted
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty universe
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty-updates universe
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty-backports main restricted universe multiverse
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty-security main restricted
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty-security universe
+deb [arch=amd64]  http://10.135.81.78/ubuntu trusty-security multiverse
+#
+#deb [arch=amd64] http://10.135.81.78/puppetlabs trusty main
+

--- a/manifests/default_manifest.pp
+++ b/manifests/default_manifest.pp
@@ -2,7 +2,7 @@
 # Class rjil::default_manifest
 #
 class rjil::default_manifest {
-  if ($::settings::default_manifest == './manifests') {
+  if ($::settings::default_manifest == './manifests' or $::settings::default_manifest == '') {
     $val = '/etc/puppet/manifests/site.pp'
   } else {
     $val = $::settings::default_manifest


### PR DESCRIPTION
1. smoothing out Vagrantfile to run "puppet apply --tags packages first"
2. Adding a default sources.list, this does the initial package pull faster. (WIP)
3. adding provision to move to a configurable mirror