### PR TITLE
Move tempest provision from rjil::tempest class to ocdb

### DIFF
--- a/manifests/tempest.pp
+++ b/manifests/tempest.pp
@@ -134,8 +134,6 @@ class rjil::tempest (
     'subunit',
   ])
 
-  Class ['::tempest::provision'] -> Class['::tempest']
-  include ::tempest::provision
   include ::tempest
 }
 

--- a/site.pp
+++ b/site.pp
@@ -109,6 +109,10 @@ node /^ocdb\d+/ {
   include rjil::openstack_zeromq
   include openstack_extras::keystone_endpoints
   include rjil::keystone::test_user
+
+  # provision tempest resources like images, network, users etc.
+  include tempest::provision
+
   # ensure that we don't create keystone objects until
   # the service is operational
   ensure_resource('rjil::service_blocker', 'keystone-admin', {})

--- a/spec/classes/tempest_spec.rb
+++ b/spec/classes/tempest_spec.rb
@@ -28,11 +28,6 @@ describe 'rjil::tempest' do
       'tempest::fixed_network_name'  => 'net_tempest',
       'tempest::setup_venv'          => true,
       'rjil::tempest::keystone_admin_token' => 'token',
-#      'tempest::provision::imagename'       => 'cirros',
-#      'tempest::provision::tenantname'      => 'tempest',
-#      'tempest::provision::username'        => 'tempest_user',
-#      'tempest::provision::admin_username'  => 'tempest_admin',
-#      'tempest::provision::networkname'     =>
     }
   end
 
@@ -77,7 +72,6 @@ describe 'rjil::tempest' do
       should contain_neutron_config('keystone_authtoken/admin_user').with_value('neutron')
 
       should contain_neutron_config('keystone_authtoken/admin_password').with_value('neutron')
-      should contain_class('tempest::provision')
       should contain_class('tempest')
     end
   end


### PR DESCRIPTION
rjil::tempest class would be running on gcp1 and some/all of the openstack
resources are created on ocdb, so it make sense to run the provisioning on ocdb
itself.