### PR TITLE
Only setup tempest_admin on vagrant, at and gate only

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -753,8 +753,6 @@ tempest::tempest_repo_uri: 'https://github.com/JioCloud/tempest.git'
 tempest::image_name: cirros-0.3.3
 tempest::image_name_alt: cirros-0.3.3
 tempest::flavor_ref: 1
-tempest::admin_password: tempest_admin
-tempest::admin_username: tempest_admin
 tempest::tenant_name: tempest
 tempest::username: tempest
 tempest::password: tempest

--- a/hiera/data/env/at.yaml
+++ b/hiera/data/env/at.yaml
@@ -11,3 +11,6 @@ rjil::neutron::contrail::public_cidr: 100.1.0.0/24
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,vigneshvar,alokjani,amar,ynshenoy,hanish]
 rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,vigneshvar,alokjani,amar,ynshenoy,hanish]
 rjil::base::self_signed_cert: true
+
+tempest::admin_password: tempest_admin
+tempest::admin_username: tempest_admin

--- a/hiera/data/env/gate.yaml
+++ b/hiera/data/env/gate.yaml
@@ -11,3 +11,6 @@ rjil::neutron::contrail::public_cidr: 100.1.0.0/24
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet]
 rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet]
 rjil::base::self_signed_cert: true
+
+tempest::admin_password: tempest_admin
+tempest::admin_username: tempest_admin

--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -94,3 +94,5 @@ rjil::jiocloud::dhcp::dhcppools:
                   "--nic", "3",
                   "--ilo_address ", cip)'
 rjil::base::self_signed_cert: true
+tempest::admin_password: tempest_admin
+tempest::admin_username: tempest_admin

--- a/hiera/data/env/vagrantlxc.yaml
+++ b/hiera/data/env/vagrantlxc.yaml
@@ -3,3 +3,5 @@ public_interface: eth1
 private_address: "%{ipaddress_eth1}"
 private_interface: eth1
 rjil::base::self_signed_cert: true
+tempest::admin_password: tempest_admin
+tempest::admin_username: tempest_admin


### PR DESCRIPTION
Moved tempest_admin config from common.yaml so it will only be setup on specific
environments. The idea is to only have tempest_admin on vagrant, at and gate
only and may be on staging also - this user will not be on production.