### PR TITLE
Pin Puppet to mitigate Future Parser errors

### DIFF
--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -8,6 +8,7 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 export layout="${layout}"
+export PUPPET_VER="3.7.2-1puppetlabs1"
 release="\$(lsb_release -cs)"
 if [ -n "${git_protocol}" ]; then
   export git_protocol="${git_protocol}"
@@ -38,7 +39,7 @@ then
   dpkg -i internal.deb
 fi
 apt-get update
-apt-get install -y puppet software-properties-common puppet-jiocloud jiocloud-ssl-certificate
+apt-get install -y puppet=${PUPPET_VER} puppet-common=${PUPPET_VER} software-properties-common puppet-jiocloud jiocloud-ssl-certificate
 if [ -n "${python_jiocloud_source_repo}" ]; then
   apt-get install -y python-pip python-jiocloud python-dev libffi-dev libssl-dev git
   pip install -e "${python_jiocloud_source_repo}@${python_jiocloud_source_branch}#egg=jiocloud"
@@ -72,6 +73,7 @@ if [ -n "${puppet_modules_source_repo}" ]; then
   puppet apply -e "ini_setting { basemodulepath: path => \"/etc/puppet/puppet.conf\", section => main, setting => basemodulepath, value => \"/etc/puppet/modules.overrides:/etc/puppet/modules\" }"
   puppet apply -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests.overrides/site.pp\" }"
   puppet apply -e "ini_setting { disable_per_environment_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => disable_per_environment_manifest, value => \"true\" }"
+  puppet apply -e "apt::pin { '00-puppet': explanation => 'Lets use 3.x for now', packages => 'puppet puppet-common', priority => '501', version  => '3.7.*', }"
 else
   puppet apply -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests/site.pp\" }"
 fi

--- a/manifests/jiocloud.pp
+++ b/manifests/jiocloud.pp
@@ -75,4 +75,11 @@ class rjil::jiocloud (
     setting => 'manifestdir',
   }
 
+  apt::pin { '00-puppet':
+    explanation => 'Lets use 3.x for now',
+    packages    => 'puppet puppet-common',
+    priority    => '501',
+    version     => '3.7.*',
+  }
+
 }

--- a/spec/classes/jiocloud_spec.rb
+++ b/spec/classes/jiocloud_spec.rb
@@ -55,4 +55,13 @@ describe 'rjil::jiocloud' do
     })}
  
   end
+
+  context 'Pin Puppet' do
+    it { should contain_apt__pin('00-puppet').with({
+      'packages' => 'puppet puppet-common',
+      'priority' => '501',
+      'version'  => '3.7.*',
+    })}
+  end
+
 end


### PR DESCRIPTION
Currently, the latest version of Puppet (3.7.x) gets installed from
Puppetlabs during the initial setup.
Then next version (Puppet 4) has several language changes alongwith
a new parser that is enabled by default.
I am seeing that the puppet-consul module throws an "Evaluation Error"
when tested w/ future parser.

This patch ensures that 3.x is used until all dependent modules are
fully future parser compatible.