### PR TITLE
use consul lookup for memcache service

### DIFF
--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -20,7 +20,7 @@ class rjil::nova::controller (
   $vncproxy_bind_port   = 6080,
   $consul_check_interval= '10s',
   $default_floating_pool = 'public',
-  $memcached_servers    = service_discover_dns('memcached.service.consul','ip'),
+  $memcached_servers    = sort(values(service_discover_consul('memcached'))),
   $admin_email          = 'root@localhost',
   $server_name          = 'localhost',
   $localbind_host       = '127.0.0.1',


### PR DESCRIPTION
I have intermittent issues with the ruby
DNS libraries that we are using, we should
probably completely deprecate their usage
and switch to the http consul api for
service lookups.