### PR TITLE
Hiera changes to use keystone configuration in rjil::tempest::provision

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -806,6 +806,9 @@ rjil::tempest::auth_host: "%{hiera('keystone_public_address')}"
 rjil::tempest::auth_protocol: "%{hiera('api_protocol')}"
 rjil::tempest::tempest_test_file: /home/jenkins/tempest_tests.txt
 rjil::tempest::tempest_clone_path: "%{hiera('tempest::tempest_clone_path')}"
+rjil::tempest::provision::auth_host: "%{hiera('keystone_public_address')}"
+rjil::tempest::provision::auth_port: "%{hiera('keystone_port')}"
+rjil::tempest::provision::auth_protocol: "%{hiera('api_protocol')}"
 
 
 tempest::provision::imagename: "%{hiera('tempest::image_name')}"


### PR DESCRIPTION
This patch to do hiera lookup to keystone configuration to configure
rjil::tempest::provision, without this puppet run in production fails because of
auth_host mismatch.