### PR TITLE
Add allowed local disk in the manifests

### DIFF
--- a/environment/jio.map.yaml
+++ b/environment/jio.map.yaml
@@ -1,10 +1,10 @@
 image:
   trusty: 5d246189-a666-470c-8cee-36ee489cbd9e
 flavor:
-  small: cba9c14d-146f-450c-94d1-cb3532a54bc1
-  medium: 2e0b84b5-96d5-4bef-a842-00f0e0827585
-  large: 012d5608-cac4-4733-aef1-cc6050d95548
-  storage: 012d5608-cac4-4733-aef1-cc6050d95548
+  small: da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+  medium: 8b1b17e5-55a9-46b7-90c3-57e1c1696223
+  large: 342a1fc6-0f15-41dc-966a-70f449f582fb
+  storage: 342a1fc6-0f15-41dc-966a-70f449f582fb
 networks:
    default:
      - 7270b05c-0086-44d3-994f-4099ef6fc4bf

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -17,21 +17,22 @@
 #   Memcached server port. Default: 11211
 #
 class rjil::nova::controller (
-  $vncproxy_bind_port   = 6080,
-  $consul_check_interval= '10s',
-  $default_floating_pool = 'public',
-  $memcached_servers    = sort(values(service_discover_consul('memcached'))),
-  $admin_email          = 'root@localhost',
-  $server_name          = 'localhost',
-  $localbind_host       = '127.0.0.1',
-  $memcached_port       = 11211,
-  $osapi_public_port    = 8774,
-  $ec2_public_port      = 8773,
-  $osapi_localbind_port = 18774,
-  $ec2_localbind_port   = 18773,
-  $ssl                  = false,
-  $flavors              = {},
-  $nova_auth            = {},
+  $vncproxy_bind_port      = 6080,
+  $consul_check_interval   = '10s',
+  $default_floating_pool   = 'public',
+  $memcached_servers       = sort(values(service_discover_consul('memcached'))),
+  $admin_email             = 'root@localhost',
+  $server_name             = 'localhost',
+  $localbind_host          = '127.0.0.1',
+  $memcached_port          = 11211,
+  $osapi_public_port       = 8774,
+  $ec2_public_port         = 8773,
+  $osapi_localbind_port    = 18774,
+  $ec2_localbind_port      = 18773,
+  $ssl                     = false,
+  $flavors                 = {},
+  $nova_auth               = {},
+  $max_local_block_devices = 3,
 ) {
 
 # Tests
@@ -44,6 +45,7 @@ class rjil::nova::controller (
     'DEFAULT/default_floating_pool':      value => $default_floating_pool;
     'DEFAULT/osapi_compute_listen_port':  value => $osapi_localbind_port;
     'DEFAULT/ec2_listen_port':            value => $ec2_localbind_port;
+    'DEFAULT/max_local_block_devices':    value => $max_local_block_devices;
   }
 
   include rjil::apache


### PR DESCRIPTION
This patch add the nova configuration max_local_block_devices to
rjil::nova::controller manifest so that the value can be overriden. It have
taken the default one which is 3 but will need to be overriden in production
where we need no local disks.