### PR TITLE
Disable boot from volume on environments other than jio

### DIFF
--- a/environment/hp.map.yaml
+++ b/environment/hp.map.yaml
@@ -8,3 +8,5 @@ flavor:
 networks:
    default:
      - d7c83218-276b-4e4c-8ed1-1165b44c3a44
+boot_volume:
+  default_volume: False

--- a/environment/jio_staging.map.yaml
+++ b/environment/jio_staging.map.yaml
@@ -8,3 +8,5 @@ flavor:
 networks:
   default:
     - 707e1858-4aff-456f-8a1f-3c8f6e00dd12
+boot_volume:
+  default_volume: False

--- a/environment/staging.map.yaml
+++ b/environment/staging.map.yaml
@@ -7,3 +7,5 @@ networks:
   default:
 assign_floating_ip:
   true: false
+boot_volume:
+  default_volume: False

--- a/environment/vagrant-vbox.map.yaml
+++ b/environment/vagrant-vbox.map.yaml
@@ -16,3 +16,5 @@ flavor:
   storage:
     ram: 4096
     cpu: 2
+boot_volume:
+  default_volume: False


### PR DESCRIPTION
Disabling boot from volume on other environments as it only required in
jiocloud.