### PR TITLE
Make sure /var/lib/nova/instances have right permission

### DIFF
--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -20,6 +20,15 @@ class rjil::nova::compute (
 
 
   ##
+  # Make sure /var/lib/nova/instances has appropriate permission
+  ##
+  file {'/var/lib/nova/instances':
+    ensure  => 'directory',
+    owner   => 'nova',
+    require => Package['nova-common'],
+  }
+
+  ##
   # service blocker to stmon before mon_config to be run.
   # Mon_config must be run on all ceph client nodes also.
   # Also mon_config should be setup before cinder_volume to be started,


### PR DESCRIPTION
I have seen couple of compute node have the above directory with root ownership
which was causing vm boot failures as nova compute process did not have write
permissions.