### PR TITLE
Update CORS headers in API service apache configs

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -167,7 +167,15 @@ rjil::glance::api_localbind_port: "%{hiera('glance_api_localbind_port')}"
 rjil::glance::api_public_port: "%{hiera('glance_api_port')}"
 rjil::glance::registry_localbind_port: "%{hiera('glance_registry_localbind_port')}"
 rjil::glance::registry_public_port: "%{hiera('glance_registry_port')}"
-
+rjil::glance::rewrites:
+  - comment: "Return 200 for OPTIONS request"
+    rewrite_cond: '%%{}{REQUEST_METHOD} OPTIONS'
+    rewrite_rule: ".* / [R=200,L]"
+rjil::glance::headers:
+  - 'always set Access-Control-Allow-Origin "*"'
+  - 'always set Access-Control-Allow-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Expose-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Allow-Methods "GET POST OPTIONS PUT DELETE PATCH"'
 glance::backend::rbd::rbd_store_user: "%{hiera('rjil::glance::rbd_user')}"
 glance::backend::rbd::rbd_store_pool: images
 ### End: rbd backend specific settings
@@ -235,6 +243,15 @@ rjil::neutron::contrail::fip_pool::keystone_admin_password: "%{hiera('admin_pass
 rjil::neutron::ovs::ctlplane_network_name: ctlplane
 rjil::neutron::server_name: "%{hiera('neutron_public_address')}"
 rjil::neutron::ssl: true
+rjil::neutron::rewrites:
+  - comment: "Return 200 for OPTIONS request"
+    rewrite_cond: '%%{}{REQUEST_METHOD} OPTIONS'
+    rewrite_rule: ".* / [R=200,L]"
+rjil::neutron::headers:
+  - 'always set Access-Control-Allow-Origin "*"'
+  - 'always set Access-Control-Allow-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Expose-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Allow-Methods "GET POST OPTIONS PUT DELETE PATCH"'
 
 ########### Cinder configuration
 ###################################
@@ -246,6 +263,15 @@ rjil::cinder::server_name: "%{hiera('cinder_public_address')}"
 rjil::cinder::localbind_port: "%{hiera('cinder_localbind_port')}"
 rjil::cinder::public_port: "%{hiera('cinder_port')}"
 rjil::cinder::ssl: true
+rjil::cinder::rewrites:
+  - comment: "Return 200 for OPTIONS request"
+    rewrite_cond: '%%{}{REQUEST_METHOD} OPTIONS'
+    rewrite_rule: ".* / [R=200,L]"
+rjil::cinder::headers:
+  - 'always set Access-Control-Allow-Origin "*"'
+  - 'always set Access-Control-Allow-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Expose-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Allow-Methods "GET POST OPTIONS PUT DELETE PATCH"'
 
 cinder::api::bind_host: "%{hiera('localbind_host')}"
 cinder::rpc_backend: "%{hiera('rpc_backend')}"
@@ -269,6 +295,15 @@ rjil::nova::controller::osapi_public_port: "%{hiera('nova_osapi_port')}"
 rjil::nova::controller::osapi_localbind_port: "%{hiera('nova_osapi_localbind_port')}"
 rjil::nova::controller::server_name: "%{hiera('nova_public_address')}"
 rjil::nova::controller::ssl: true
+rjil::nova::controller::rewrites:
+  - comment: "Return 200 for OPTIONS request"
+    rewrite_cond: '%%{}{REQUEST_METHOD} OPTIONS'
+    rewrite_rule: ".* / [R=200,L]"
+rjil::nova::controller::headers:
+  - 'always set Access-Control-Allow-Origin "*"'
+  - 'always set Access-Control-Allow-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Expose-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Allow-Methods "GET POST OPTIONS PUT DELETE PATCH"'
 nova::rpc_backend: "%{hiera('rpc_backend')}"
 nova::glance_api_servers: "%{hiera('api_protocol')}://%{hiera('glance_public_address')}:%{hiera('glance::keystone::auth::public_port')}"
 nova::database_connection: "mysql://%{hiera('nova_db_user')}:%{hiera('nova_db_password')}@%{hiera('db_host')}/nova"
@@ -388,6 +423,15 @@ rjil::keystone::admin_port: "%{hiera('keystone_admin_port')}"
 rjil::keystone::admin_port_internal: "%{hiera('keystone_admin_localbind_port')}"
 rjil::keystone::public_address: "%{hiera('public_address')}"
 rjil::keystone::server_name: "%{hiera('keystone_public_address')}"
+rjil::keystone::rewrites:
+  - comment: "Return 200 for OPTIONS request"
+    rewrite_cond: '%%{}{REQUEST_METHOD} OPTIONS'
+    rewrite_rule: ".* / [R=200,L]"
+rjil::keystone::headers:
+  - 'always set Access-Control-Allow-Origin "*"'
+  - 'always set Access-Control-Allow-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Expose-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Allow-Methods "GET POST OPTIONS PUT DELETE PATCH"'
 keystone::roles::admin::email: "%{hiera('admin_email')}"
 keystone::roles::admin::password: "%{hiera('admin_password')}"
 keystone::admin_password: "%{hiera('admin_password')}"
@@ -682,9 +726,16 @@ ceph::radosgw::listen_ssl: true
 
 rjil::ceph::radosgw::ssl: true
 
-# below header is required to enable CORS.
+ceph::radosgw::apache::rewrites:
+  - comment: "Return 200 for OPTIONS request"
+    rewrite_cond: '%%{}{REQUEST_METHOD} OPTIONS'
+    rewrite_rule: ".* / [R=200,L]"
+# below headers are required to enable CORS.
 ceph::radosgw::apache::headers:
-  - 'set Access-Control-Allow-Origin "*"'
+  - 'always set Access-Control-Allow-Origin "*"'
+  - 'always set Access-Control-Allow-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Expose-Headers "Accept, Content-Type, X-Auth-Token, X-Subject-Token"'
+  - 'always set Access-Control-Allow-Methods "GET POST OPTIONS PUT DELETE PATCH"'
 radosgw_protocol: "%{hiera('api_protocol')}"
 radosgw_port: 80
 

--- a/manifests/cinder.pp
+++ b/manifests/cinder.pp
@@ -62,6 +62,8 @@ class rjil::cinder (
   $localbind_port          = 18776,
   $ssl                     = false,
   $volume_nofile           = 10240,
+  $rewrites                = undef,
+  $headers                 = undef,
 ) {
 
   ######################## Service Blockers and Ordering
@@ -118,7 +120,8 @@ class rjil::cinder (
     error_log_file  => 'cinder.log',
     access_log_file => 'cinder.log',
     proxy_pass      => [ { path => '/', url => "http://${localbind_host}:${localbind_port}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   ##

--- a/manifests/glance.pp
+++ b/manifests/glance.pp
@@ -17,6 +17,8 @@ class rjil::glance (
   $registry_public_address = '127.0.0.1',
   $registry_public_port    = '9191',
   $ssl                     = false,
+  $rewrites                = undef,
+  $headers                 = undef,
 ) {
 
   ## Add tests for glance api and registry
@@ -51,7 +53,8 @@ class rjil::glance (
     error_log_file  => 'glance-api.log',
     access_log_file => 'glance-api.log',
     proxy_pass      => [ { path => '/', url => "http://${api_localbind_host}:${api_localbind_port}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   apache::vhost { 'glance-registry':
@@ -63,7 +66,8 @@ class rjil::glance (
     error_log_file  => 'glance-registry.log',
     access_log_file => 'glance-registry.log',
     proxy_pass      => [ { path => '/', url => "http://${registry_localbind_host}:${registry_localbind_port}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   if($backend == 'swift') {

--- a/manifests/keystone.pp
+++ b/manifests/keystone.pp
@@ -17,6 +17,8 @@ class rjil::keystone(
   $cache_backend          = undef,
   $cache_backend_argument = undef,
   $disable_db_sync        = false,
+  $rewrites               = undef,
+  $headers                = undef,
 ) {
 
   if $public_address == '0.0.0.0' {
@@ -76,7 +78,8 @@ class rjil::keystone(
     error_log_file  => 'keystone.log',
     access_log_file => 'keystone.log',
     proxy_pass      => [ { path => '/', url => "http://localhost:${public_port_internal}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   ## Configure apache reverse proxy
@@ -89,7 +92,8 @@ class rjil::keystone(
     error_log_file  => 'keystone.log',
     access_log_file => 'keystone.log',
     proxy_pass      => [ { path => '/', url => "http://localhost:${admin_port_internal}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   ## Keystone cache configuration

--- a/manifests/neutron.pp
+++ b/manifests/neutron.pp
@@ -10,6 +10,8 @@ class rjil::neutron (
   $public_port          = 9696,
   $localbind_port       = 19696,
   $ssl                  = false,
+  $rewrites             = undef,
+  $headers              = undef,
 ) {
 
   ##
@@ -48,7 +50,8 @@ class rjil::neutron (
     error_log_file  => 'neutron.log',
     access_log_file => 'neutron.log',
     proxy_pass      => [ { path => '/', url => "http://${localbind_host}:${localbind_port}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   ##

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -33,6 +33,8 @@ class rjil::nova::controller (
   $flavors                 = {},
   $nova_auth               = {},
   $max_local_block_devices = 3,
+  $rewrites                = undef,
+  $headers                 = undef,
 ) {
 
 # Tests
@@ -61,7 +63,8 @@ class rjil::nova::controller (
     error_log_file  => 'nova-osapi.log',
     access_log_file => 'nova-osapi.log',
     proxy_pass      => [ { path => '/', url => "http://${localbind_host}:${osapi_localbind_port}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   apache::vhost { 'nova-ec2api':
@@ -73,7 +76,8 @@ class rjil::nova::controller (
     error_log_file  => 'nova-ec2api.log',
     access_log_file => 'nova-ec2api.log',
     proxy_pass      => [ { path => '/', url => "http://${localbind_host}:${ec2_localbind_port}/"  } ],
-    headers         => [ 'set Access-Control-Allow-Origin "*"' ],
+    rewrites        => $rewrites,
+    headers         => $headers,
   }
 
   ##

--- a/spec/classes/cinder_spec.rb
+++ b/spec/classes/cinder_spec.rb
@@ -77,7 +77,6 @@ describe 'rjil::cinder' do
           'error_log_file'  => 'cinder.log',
           'access_log_file' => 'cinder.log',
           'proxy_pass'      => [ { 'path' => '/', 'url' => "http://127.0.0.1:18776/"  } ],
-          'headers'         => [ 'set Access-Control-Allow-Origin "*"' ],
         }
       )
       should contain_ceph__conf__clients('cinder_volume').with({

--- a/spec/classes/glance_spec.rb
+++ b/spec/classes/glance_spec.rb
@@ -48,7 +48,6 @@ describe 'rjil::glance' do
           'error_log_file'  => 'glance-api.log',
           'access_log_file' => 'glance-api.log',
           'proxy_pass'      => [ { 'path' => '/', 'url' => "http://127.0.0.1:19292/"  } ],
-          'headers'         => [ 'set Access-Control-Allow-Origin "*"' ],
         }
       )
 
@@ -62,7 +61,6 @@ describe 'rjil::glance' do
           'error_log_file'  => 'glance-registry.log',
           'access_log_file' => 'glance-registry.log',
           'proxy_pass'      => [ { 'path' => '/', 'url' => "http://127.0.0.1:19191/"  } ],
-          'headers'         => [ 'set Access-Control-Allow-Origin "*"' ],
         }
       )
 

--- a/spec/classes/keystone_spec.rb
+++ b/spec/classes/keystone_spec.rb
@@ -52,7 +52,7 @@ describe 'rjil::keystone' do
             'serveradmin' => 'root@rjil.com',
             'port'        => '5001',
             'ssl'         => true,
-            'proxy_pass'  => [ { 'path' => '/', 'url' => "http://localhost:5000/"  } ]
+            'proxy_pass'  => [ { 'path' => '/', 'url' => "http://localhost:5000/"  } ],
           }
         )
         should contain_apache__vhost('keystone-admin').with(
@@ -61,7 +61,7 @@ describe 'rjil::keystone' do
             'serveradmin' => 'root@rjil.com',
             'port'        => '35356',
             'ssl'         => true,
-            'proxy_pass'  => [ { 'path' => '/', 'url' => "http://localhost:35357/"  } ]
+            'proxy_pass'  => [ { 'path' => '/', 'url' => "http://localhost:35357/"  } ],
           }
         )
         should contain_file('/usr/lib/jiocloud/tests/keystone.sh').with_content(/check_http -S -H 127\.0\.0\.1 -p 5001/)

--- a/spec/classes/neutron_spec.rb
+++ b/spec/classes/neutron_spec.rb
@@ -66,7 +66,6 @@ describe 'rjil::neutron' do
         'error_log_file'  => 'neutron.log',
         'access_log_file' => 'neutron.log',
         'proxy_pass'      => [ { 'path' => '/', 'url' => 'http://127.0.0.1:19696/'  } ],
-        'headers'         => [ 'set Access-Control-Allow-Origin "*"' ],
       })
 
     end

--- a/spec/classes/nova/controller_spec.rb
+++ b/spec/classes/nova/controller_spec.rb
@@ -50,7 +50,6 @@ describe 'rjil::nova::controller' do
           'error_log_file'  => 'nova-osapi.log',
           'access_log_file' => 'nova-osapi.log',
           'proxy_pass'      => [ { 'path' => '/', 'url' => "http://127.0.0.1:18774/"  } ],
-          'headers'         => [ 'set Access-Control-Allow-Origin "*"' ],
         }
       )
 
@@ -64,7 +63,6 @@ describe 'rjil::nova::controller' do
           'error_log_file'  => 'nova-ec2api.log',
           'access_log_file' => 'nova-ec2api.log',
           'proxy_pass'      => [ { 'path' => '/', 'url' => "http://127.0.0.1:18773/"  } ],
-          'headers'         => [ 'set Access-Control-Allow-Origin "*"' ],
         }
       )
 


### PR DESCRIPTION
This change corrects the CORS header to 'always set'
It adds another header to allow 'Content-Type' in the
request headers.
An explicit rewrite rule to return 200 for the OPTIONS
request has also been added because OpenStack services
(like Keystone) yield 404 for OPTIONS requests.