### PR TITLE
Set $fail within local scope for Ceph mons

### DIFF
--- a/manifests/ceph/mon/mon_config.pp
+++ b/manifests/ceph/mon/mon_config.pp
@@ -52,7 +52,7 @@ class rjil::ceph::mon::mon_config (
     ::ceph::conf::mon_config{ $other_mons: }
   } elsif ! $leader {
     runtime_fail {'monlist_empty_fail':
-      fail    => $fail,
+      fail    => true,
       message => 'External Mon list cannot be empty for non-leader mon nodes',
       # this the exact dependency that we are waiting for...
       before  => Exec['ceph-mon-keyring'],

--- a/manifests/ceph/mon_config.pp
+++ b/manifests/ceph/mon_config.pp
@@ -15,6 +15,8 @@ class rjil::ceph::mon_config (
   if ! empty($mon_config) {
     ::ceph::conf::mon_config{ $mon_config: }
     $fail = false
+  } else {
+    $fail = true
   }
 
   # mon_config should be finished before any ceph::auth execution which will


### PR DESCRIPTION
This patch fixes the `top-scope variable being used without an
explicit namespace` warning by setting $fail to true for
manifests/ceph/mon/mon_config.pp
Also set $fail explicitly in manifests/ceph/mon_config.pp

This closes issue #444