### PR TITLE
Enable set operations using haproxy socket

### DIFF
--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -35,7 +35,7 @@ class rjil::haproxy (
     'group'     => 'haproxy',
     'daemon'    => '',
     'quiet'     => '',
-    'stats'     => 'socket /var/run/haproxy mode 777',
+    'stats'     => 'socket /var/run/haproxy level admin',
   }
 
   class { '::haproxy':


### PR DESCRIPTION
This will enable set operatins using which you do write operations like
enable/disable servers using socat through haproxy socket (We can build toolset
on that)