### PR TITLE
Casandra and zookeeper should be up before contrail packages

### DIFF
--- a/manifests/cassandra.pp
+++ b/manifests/cassandra.pp
@@ -55,4 +55,13 @@ class rjil::cassandra (
     require           => Host['localhost'],
   }
 
+  ##
+  # I dont know if the port check is enough here - refer
+  # https://github.com/JioCloud/puppet-rjil/issues/521 for more details
+  ##
+  rjil::jiocloud::consul::service { "cassandra":
+    tags          => ['real','contrail'],
+    check_command => '/usr/lib/jiocloud/tests/check_cassandra.sh',
+  }
+
 }

--- a/manifests/contrail/server.pp
+++ b/manifests/contrail/server.pp
@@ -25,5 +25,16 @@ class rjil::contrail::server () {
   Rjil::Service_blocker['zookeeper'] -> Package['contrail-dns']
   Rjil::Service_blocker['zookeeper'] -> Package['contrail-analytics']
 
+
+  Package['zookeeper'] -> Package['contrail-config-openstack']
+  Package['zookeeper'] -> Package['contrail-control']
+  Package['zookeeper'] -> Package['contrail-dns']
+  Package['zookeeper'] -> Package['contrail-analytics']
+
+  Package['dsc'] -> Package['contrail-config-openstack']
+  Package['dsc'] -> Package['contrail-control']
+  Package['dsc'] -> Package['contrail-dns']
+  Package['dsc'] -> Package['contrail-analytics']
+
   include ::contrail
 }

--- a/manifests/contrail/server.pp
+++ b/manifests/contrail/server.pp
@@ -12,5 +12,18 @@ class rjil::contrail::server () {
                       'contrail-webui-webserver.sh','contrail-webui-jobserver.sh']
   rjil::test {$contrail_tests:}
 
+  ensure_resource( 'rjil::service_blocker', 'cassandra', {})
+  ensure_resource( 'rjil::service_blocker', 'zookeeper', {})
+
+  Rjil::Service_blocker['cassandra'] -> Package['contrail-config-openstack']
+  Rjil::Service_blocker['cassandra'] -> Package['contrail-control']
+  Rjil::Service_blocker['cassandra'] -> Package['contrail-dns']
+  Rjil::Service_blocker['cassandra'] -> Package['contrail-analytics']
+
+  Rjil::Service_blocker['zookeeper'] -> Package['contrail-config-openstack']
+  Rjil::Service_blocker['zookeeper'] -> Package['contrail-control']
+  Rjil::Service_blocker['zookeeper'] -> Package['contrail-dns']
+  Rjil::Service_blocker['zookeeper'] -> Package['contrail-analytics']
+
   include ::contrail
 }

--- a/manifests/contrail/server.pp
+++ b/manifests/contrail/server.pp
@@ -37,4 +37,8 @@ class rjil::contrail::server () {
   Package['dsc'] -> Package['contrail-analytics']
 
   include ::contrail
+
+  include zookeeper
+
+  include cassandra
 }

--- a/manifests/zookeeper.pp
+++ b/manifests/zookeeper.pp
@@ -20,4 +20,13 @@ class rjil::zookeeper (
     id => $zk_id,
   }
 
+  ##
+  # I dont know if the port check is enough here - refer
+  # https://github.com/JioCloud/puppet-rjil/issues/521 for more details
+  ##
+  rjil::jiocloud::consul::service { 'zookeeper':
+    tags          => ['real','contrail'],
+    check_command => '/usr/lib/jiocloud/tests/check_zookeeper.sh',
+  }
+
 }

--- a/spec/classes/contrail/server_spec.rb
+++ b/spec/classes/contrail/server_spec.rb
@@ -8,8 +8,10 @@ describe 'rjil::contrail::server' do
       :osfamily        => 'Debian',
       :ipaddress_eth0  => '10.1.1.1',
       :interfaces      => 'eth0,lo',
-      :lsbdistid        => 'ubuntu',
-      :lsbdistcodename  => 'trusty',
+      :lsbdistid       => 'ubuntu',
+      :lsbdistcodename => 'trusty',
+      :processorcount  => '10',
+      :ipaddress       => '10.1.1.1',
     }
   end
   let :hiera_data do
@@ -18,6 +20,7 @@ describe 'rjil::contrail::server' do
       'contrail::keystone_admin_token'    => 'admin_token',
       'contrail::keystone_admin_password' => 'admin_pass',
       'contrail::keystone_auth_password'  => 'auth_pass',
+      'cassandra::seeds'                  => ['10.0.0.1'],
     }
   end
 

--- a/spec/classes/neutron_contrail_spec.rb
+++ b/spec/classes/neutron_contrail_spec.rb
@@ -13,6 +13,8 @@ describe 'rjil::neutron::contrail' do
       :ipaddress_eth0         => '10.1.1.100',
       :lsbdistid              => 'ubuntu',
       :lsbdistcodename        => 'trusty',
+      :processorcount         => '10',      
+      :ipaddress              => '10.1.1.1',
     }
   end
   let :hiera_data do


### PR DESCRIPTION
Created a service blockers for some packages which start services to use the
cassandra and zookeeper, so that they will not be installed unless cassandra and
zookeeper are started. The packae installation can start the application and the
default configuration may be enough to write the data to either of these
application.

We have seen a possible situation when zookeeper is up, and contrail-api is
starting but cassandra is not writable there, in which case, contrail-api can
create some zookeeper entries while creating cassandra entries, but since
cassandra is not writable, that operation fail (writing cassandra). So whenever
they try this operation again, the code try to create the uids using zk, but
since zk have those object already exists, the operation fail and thus contrail
api fail (this must be a bug in contrail api though).

Please see https://github.com/JioCloud/puppet-rjil/issues/521 for more details