### PR TITLE
add package tag to apt::pin

### DIFF
--- a/manifests/system/apt.pp
+++ b/manifests/system/apt.pp
@@ -14,7 +14,11 @@ class rjil::system::apt (
   Apt::Source<||> {
     tag => 'package',
   }
+  Apt::Pin<||> {
+    tag => 'package',
+  }
   Apt::Source<||> -> Package<||>
+  Apt::Pin<||> -> Package<||>
 
   if $enable_puppetlabs {
     include puppet::repo::puppetlabs


### PR DESCRIPTION
I have seen issues where dsc fails to install
during the package installation phase.

This should resolve the issue by ensuring that
we are correctly pinning pin the package during
that run.