### PR TITLE
Add simple service feature

### DIFF
--- a/files/package_start_policy.sh
+++ b/files/package_start_policy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+name="$1"
+sensitive_services_list=/etc/sensitive_services
+grep -x "$name" "$sensitive_services_list" && exit 101
+exit 0

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -8,6 +8,7 @@ class rjil::base (
   include rjil::system
   include rjil::jiocloud::dns
   include rjil::default_manifest
+  include rjil::system::sensitive_services
   ##
   # In case of self signed certificate mostly all of the servers need to trust
   # tht certificate as it is required to do api calls to any openstack services

--- a/manifests/system/sensitive_services.pp
+++ b/manifests/system/sensitive_services.pp
@@ -3,7 +3,10 @@
 # be started during the initial bootstrappig package install.
 #
 class rjil::system::sensitive_services(
-  $service_list = ['zookeeper', 'cassandra', 'contrail-api', 'contrail-schema']
+  $service_list = [ 'zookeeper', 'cassandra',
+                    'contrail-api', 'contrail-schema', 'contrail-svc-monitor', 'contrail-discovery',
+                    'contrail-control', 'contrail-dns',
+                    'contrail-query-engine', 'contrail-collector', 'contrail-analytics-api']
 ) {
 
   File['/usr/sbin/policy-rc.d'] -> Package<||>
@@ -13,6 +16,7 @@ class rjil::system::sensitive_services(
   # starting services
   file { '/usr/sbin/policy-rc.d':
     source => 'puppet:///modules/rjil/package_start_policy.sh',
+    mode   => '0755',
     tag    => 'package',
   }
 

--- a/manifests/system/sensitive_services.pp
+++ b/manifests/system/sensitive_services.pp
@@ -1,0 +1,30 @@
+#
+# This class is used to manage all services that should not
+# be started during the initial bootstrappig package install.
+#
+class rjil::system::sensitive_services(
+  $service_list = ['zookeeper', 'cassandra', 'contrail-api', 'contrail-schema']
+) {
+
+  File['/usr/sbin/policy-rc.d'] -> Package<||>
+  File['/etc/sensitive_services'] -> Package<||>
+
+  # this file can be used to override the default package policy for
+  # starting services
+  file { '/usr/sbin/policy-rc.d':
+    source => 'puppet:///modules/rjil/package_start_policy.sh',
+    tag    => 'package',
+  }
+
+  # This file is just for bootstrapping central services. Once this file exists,
+  # the entries should be deleted from file_line resources, so the file should
+  # not be updated by this resource if it already exists
+  file { '/etc/sensitive_services':
+    content => template('rjil/sensitive_services.erb'),
+    replace => false,
+    tag     => 'package',
+  }
+
+  rjil::system::sensitive_services::activator { $service_list: }
+
+}

--- a/manifests/system/sensitive_services/activator.pp
+++ b/manifests/system/sensitive_services/activator.pp
@@ -1,0 +1,16 @@
+#
+# Used to active services. This is done by removing
+# the service name line from our sensitive_services
+# config file.
+#
+define rjil::system::sensitive_services::activator {
+
+  Service<| title == $name |> -> File_line["sensitive_service_${name}"]
+
+  file_line { "sensitive_service_${name}":
+    ensure => absent,
+    path   => '/etc/sensitive_services',
+    line   => $name,
+  }
+
+}

--- a/spec/classes/system/sensitive_services_spec.rb
+++ b/spec/classes/system/sensitive_services_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'rjil::system::sensitive_services' do
+
+  context 'with defaults' do
+
+    it 'should have default objects' do
+      should contain_file('/usr/sbin/policy-rc.d').with({
+        'tag'    => 'package',
+        'source' => 'puppet:///modules/rjil/package_start_policy.sh'
+      })
+      should contain_file('/etc/sensitive_services').with({
+        'content' => "# managed by puppet\n# a list of services that should not be started\n# from package based actions. This file is called\n# from policy-rc.d\nzookeeper\ncassandra\ncontrail-api\ncontrail-schema\n",
+        'replace' => false,
+      })
+      ['zookeeper', 'cassandra', 'contrail-api', 'contrail-schema'].each do |x|
+        should contain_file_line("sensitive_service_#{x}").with({
+          'ensure' => 'absent',
+          'path'   => '/etc/sensitive_services',
+          'line'   => x,
+        })
+      end
+    end
+  end
+end

--- a/spec/classes/system/sensitive_services_spec.rb
+++ b/spec/classes/system/sensitive_services_spec.rb
@@ -7,10 +7,11 @@ describe 'rjil::system::sensitive_services' do
     it 'should have default objects' do
       should contain_file('/usr/sbin/policy-rc.d').with({
         'tag'    => 'package',
-        'source' => 'puppet:///modules/rjil/package_start_policy.sh'
+        'source' => 'puppet:///modules/rjil/package_start_policy.sh',
+        'mode'   => '0755',
       })
       should contain_file('/etc/sensitive_services').with({
-        'content' => "# managed by puppet\n# a list of services that should not be started\n# from package based actions. This file is called\n# from policy-rc.d\nzookeeper\ncassandra\ncontrail-api\ncontrail-schema\n",
+        'content' => "# managed by puppet\n# a list of services that should not be started\n# from package based actions. This file is called\n# from policy-rc.d\nzookeeper\ncassandra\ncontrail-api\ncontrail-schema\ncontrail-svc-monitor\ncontrail-discovery\ncontrail-control\ncontrail-dns\ncontrail-query-engine\ncontrail-collector\ncontrail-analytics-api\n",
         'replace' => false,
       })
       ['zookeeper', 'cassandra', 'contrail-api', 'contrail-schema'].each do |x|

--- a/templates/sensitive_services.erb
+++ b/templates/sensitive_services.erb
@@ -1,0 +1,7 @@
+# managed by puppet
+# a list of services that should not be started
+# from package based actions. This file is called
+# from policy-rc.d
+<% @service_list.each do |service_name| -%>
+<%= service_name %>
+<% end -%>


### PR DESCRIPTION
In some cases, we need to delay starting
an application during bootstrapping so that
we can perform configuration to prepare a cluster
before we can start the service.

In some extreme cases, have package installs start
services can lead to split-brain cases and cause issues
with data replicate and initialization acorss clusters.

This patch implements the ability to delay starting a
specific list of services (initially: zookeeper, cassandra,
contrail-schema, and contrail-api) and ensure that the package
will not attempt to start them until after the service resourcs
in puppet has run.