### PR TITLE
osd test should handle loop devices also

### DIFF
--- a/templates/tests/ceph_osd.sh.rb
+++ b/templates/tests/ceph_osd.sh.rb
@@ -7,5 +7,9 @@ function fail {
   exit 2
 }
 
+<%- if @disk =~ /loop/ %>
+osdid=`df -h | grep "/dev/<%= @disk %>p[0-9]" | awk '{print $NF}' | cut -f2 -d-`
+<%- else %>
 osdid=`df -h | grep "/dev/<%= @disk %>[^a-z]" | awk '{print $NF}' | cut -f2 -d-`
+<%- end %>
 ps -efw | grep ceph-osd | grep osd.${osdid}.pid || fail "osd failed"


### PR DESCRIPTION
This patch will make ceph test work for loop devices also where the partition
have different naming convention.