### PR TITLE
Clean up created networks even when creation fails

### DIFF
--- a/files/tests/neutron.sh
+++ b/files/tests/neutron.sh
@@ -7,17 +7,17 @@ function fail {
 
 if [ -f /root/openrc ]; then
   source /root/openrc
+  netname=`hostname`
   neutron net-list -D || fail 'neutron net-list failed'
-  neutron net-create testnet || fail 'neutron net-create failed'
-  netid=`neutron net-list -D | awk '/[a-z][a-z]*[0-9][0-9]*/ {print $2}' | head -1`
-  neutron subnet-create $netid 10.0.0.0/24 || fail 'neutron subnet-create failed'
-  neutron port-create $netid || fail 'neutron port-create failed'
-  for port in `neutron port-list | awk '/[a-z][a-z]*[0-9][0-9]*/ {print $2}'`; do
-    neutron port-delete $port || fail 'neutron port-delete failed'
-  done
-  for net in `neutron net-list -D  | awk '/[a-z][a-z]*[0-9][0-9]*/ {print $2}'`; do
+  for net in `neutron net-list -D | grep $netname | awk '/[a-z][a-z]*[0-9][0-9]*/ {print $2}'`; do
+    echo "Found unexpected network leftover from previous test"
     neutron net-delete $net || fail 'neutron net-delete failed'
   done
+  netid=`neutron net-create $netname | grep ' id ' | awk  '{print $4}'` || fail 'failed to create network'
+  neutron subnet-create $netid 10.0.0.0/24 || fail 'neutron subnet-create failed'
+  portid=`neutron port-create $netid | grep ' id ' | awk  '{print $4}'` || fail 'neutron port-create failed'
+  neutron port-delete $portid || fail "Could not delete port $portid"
+  neutron net-delete $netid || fail "Could not delete network $netid"
 else
   echo 'Critical: Openrc does not exist'
   exit 2


### PR DESCRIPTION
Currently, it's possible for neutron to get stuck into
a state where it continuously creates test networks
forever. This is because a failure to create will
cause deletion to not be performed. This means that
a single failed network delete will cause this test
to enter a state where it cannot create the subnet
(due to overlapping subnets) b/c one was not deleted.

When it enters this state, it continuously fails and
creates additional networks.