### PR TITLE
Disable contrail analytics

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -142,8 +142,8 @@ mod 'stephenrjohnson/puppet',
   :ref => '1.0.0'
 
 mod 'jiocloud/contrail',
-  :git => "#{base_url}/jiocloud/jiocloud-contrail",
-  :ref => 'origin/master'
+  :git => "#{base_url}/hkumarmk/jiocloud-contrail",
+  :ref => 'optional-disable-analytics'
 
 mod 'deric/zookeeper',
   :git => "#{base_url}/deric/puppet-zookeeper",

--- a/Puppetfile
+++ b/Puppetfile
@@ -142,8 +142,8 @@ mod 'stephenrjohnson/puppet',
   :ref => '1.0.0'
 
 mod 'jiocloud/contrail',
-  :git => "#{base_url}/hkumarmk/jiocloud-contrail",
-  :ref => 'optional-disable-analytics'
+  :git => "#{base_url}/jiocloud/jiocloud-contrail",
+  :ref => 'origin/master'
 
 mod 'deric/zookeeper',
   :git => "#{base_url}/deric/puppet-zookeeper",

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -631,6 +631,8 @@ contrail::vrouter::manage_repo: false
 contrail::neutron_ip: "%{hiera('neutron_public_address')}"
 contrail::enable_analytics: false
 
+rjil::contrail::server::enable_analytics: false
+
 ##
 # Adding common setting for contrail::interface, this may need to be override in
 # environment specific interface

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -629,6 +629,7 @@ contrail::vrouter::keystone_admin_password: "%{hiera('admin_password')}"
 contrail::manage_repo: false
 contrail::vrouter::manage_repo: false
 contrail::neutron_ip: "%{hiera('neutron_public_address')}"
+contrail::enable_analytics: false
 
 ##
 # Adding common setting for contrail::interface, this may need to be override in

--- a/manifests/contrail/server.pp
+++ b/manifests/contrail/server.pp
@@ -1,16 +1,22 @@
 ###
 ## Class: rjil::contrail
 ###
-class rjil::contrail::server () {
+class rjil::contrail::server (
+  $enable_analytics = true,
+) {
 
   ##
   # Added tests
   ##
-  $contrail_tests = ['ifmap.sh','contrail-analytics.sh','contrail-api.sh',
+  $contrail_tests = ['ifmap.sh','contrail-api.sh',
                       'contrail-control.sh','contrail-discovery.sh',
                       'contrail-dns.sh','contrail-schema.sh',
                       'contrail-webui-webserver.sh','contrail-webui-jobserver.sh']
   rjil::test {$contrail_tests:}
+
+  if $enable_analytics {
+    rjil::test {'contrail-analytics.sh':}
+  }
 
   include ::contrail
 }


### PR DESCRIPTION
We are not using analytics data at this moment, so it doesnt make sense to
collect all these data especially because contrail collector who collect all the
network flows and other details is a heavy process which cause others to
slowdown. So disabling contrail-analytics for now.