### PR TITLE
Use eatmydata for apt-get and dpkg for at, to speedup the things

### DIFF
--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -28,6 +28,13 @@ wget -O puppet.deb -t 5 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${re
 if [ "${env}" == "at" ]
 then
   jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}-testing.deb
+  ##
+  # Install eatmydata and replace apt-get and dpkg with eatmydata, this should
+  # speedup the package installation
+  ##
+  apt-get install eatmydata
+  mv /usr/bin/apt-get /usr/local/bin/ && ln -s /usr/bin/eatmydata /usr/bin/apt-get
+  mv /usr/bin/dpkg /usr/local/bin/ && ln -s /usr/bin/eatmydata /usr/bin/dpkg
 else
   jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}.deb
 fi


### PR DESCRIPTION
This patch eatmydata for apt-get and dpkg in at environment. This should speedup
package installation and thus overall gate/at execution time.