### PR TITLE
fix neutron test script according to soren comments

### DIFF
--- a/files/tests/neutron.sh
+++ b/files/tests/neutron.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 function fail {
+  eval $cleanup_command
   echo "CRITICAL: $@"
   exit 2
 }
@@ -9,15 +10,12 @@ if [ -f /root/openrc ]; then
   source /root/openrc
   netname=`hostname`
   neutron net-list -D || fail 'neutron net-list failed'
-  for net in `neutron net-list -D | grep $netname | awk '/[a-z][a-z]*[0-9][0-9]*/ {print $2}'`; do
-    echo "Found unexpected network leftover from previous test"
-    neutron net-delete $net || fail 'neutron net-delete failed'
-  done
   netid=`neutron net-create $netname | grep ' id ' | awk  '{print $4}'` || fail 'failed to create network'
+  cleanup_command="neutron net-delete ${netid}"
   neutron subnet-create $netid 10.0.0.0/24 || fail 'neutron subnet-create failed'
   portid=`neutron port-create $netid | grep ' id ' | awk  '{print $4}'` || fail 'neutron port-create failed'
-  neutron port-delete $portid || fail "Could not delete port $portid"
-  neutron net-delete $netid || fail "Could not delete network $netid"
+  cleanup_command="neutron port-delete ${portid} ; ${cleanup_command}"
+  eval $cleanup_command || fail "Could not cleanup, retrying"
 else
   echo 'Critical: Openrc does not exist'
   exit 2


### PR DESCRIPTION
this patch updates the neutron test script to make
it a little more reliable.

1. Do not delete arbitrary networks, it is too scary. If
previous ones get left, just leave them there and clean
them up manually.
2. Keep a list of objects to delete so that we can ensure
that we also remove them on failures cases (or at least
try to)