### PR TITLE
Add the concept of an override_repo

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -68,7 +68,7 @@ fixtures:
       ref: 'origin/svn_to_git_2'
     apt:
       repo: https://github.com/puppetlabs/puppetlabs-apt
-      ref: 1.6.0
+      ref: 1.8.0
     cinder:
       repo: https://github.com/stackforge/puppet-cinder
       ref: 4.0.0

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -56,7 +56,10 @@ fixtures:
       ref: 1.1.2
     staging:
       repo: https://github.com/nanliu/puppet-staging
-      ref: 0.4.0
+      ref: 9c1c08af301dabe35c0d95ee7de9ab6ef2343139
+    archive:
+      repo: https://github.com/puppet-community/puppet-archive
+      ref: f875114ecb962a0d02b4496fab6a871ca1e637c1
     apache:
       repo: https://github.com/puppetlabs/puppetlabs-apache
       ref: 1.2.0

--- a/Puppetfile
+++ b/Puppetfile
@@ -67,7 +67,7 @@ mod 'puppetlabs/apache',
 
 mod 'puppetlabs/apt',
   :git => "#{base_url}/puppetlabs/puppetlabs-apt",
-  :ref => '1.6.0'
+  :ref => '1.8.0'
 
 mod 'stackforge/cinder',
   :git => "#{base_url}/stackforge/puppet-cinder",

--- a/Puppetfile
+++ b/Puppetfile
@@ -61,10 +61,6 @@ mod 'saz/timezone',
   :git => "#{base_url}/saz/puppet-timezone",
   :ref => 'v2.0.0'
 
-mod 'nanliu/staging',
-  :git => "#{base_url}/nanliu/puppet-staging",
-  :ref => '0.4.1'
-
 mod 'puppetlabs/apache',
   :git => "#{base_url}/puppetlabs/puppetlabs-apache",
   :ref => '1.2.0'
@@ -199,3 +195,11 @@ mod 'puppetlabs/dhcp',
 mod 'rodjek/logrotate',
   :git => "#{base_url}/rodjek/puppet-logrotate/",
   :ref => '89ee645e2350045be48df7ac3ef86cbe4cd9b096'
+
+mod 'nanliu/staging',
+  :git => "#{base_url}/nanliu/puppet-staging",
+  :ref => '9c1c08af301dabe35c0d95ee7de9ab6ef2343139'
+
+mod 'community/archive',
+  :git => "#{base_url}/puppet-community/puppet-archive",
+  :ref => 'f875114ecb962a0d02b4496fab6a871ca1e637c1'

--- a/README.md
+++ b/README.md
@@ -723,6 +723,10 @@ Provide a DNS server to use during bootstrapping. This will replace the
 contents of /etc/resolv.conf during the bootstrapping process and until
 it is changed back to localhost for consul.
 
+### override\_repo
+
+a file location for a tgz file that stores a repo that needs to be added for development or testing of new repo features.
+
 ## Example of a full invocation
 
 This is what I used for testing:

--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -9,6 +9,7 @@ export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 export layout="${layout}"
 release="\$(lsb_release -cs)"
+sudo mkdir -p /etc/facter/facts.d
 if [ -n "${git_protocol}" ]; then
   export git_protocol="${git_protocol}"
 fi
@@ -47,6 +48,10 @@ do
   n=\$((\$n+1))
   sleep 5
 done
+if [ -n "${override_repo}" ]; then
+  echo "override_repo=${override_repo}" > /etc/facter/facts.d/override_repo.txt
+  time gem install faraday faraday_middleware --no-ri --no-rdoc;
+fi
 if [ -n "${python_jiocloud_source_repo}" ]; then
   apt-get install -y python-pip python-jiocloud python-dev libffi-dev libssl-dev git
   pip install -e "${python_jiocloud_source_repo}@${python_jiocloud_source_branch}#egg=jiocloud"
@@ -93,7 +98,6 @@ INISETTING
 else
   puppet apply -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests/site.pp\" }"
 fi
-sudo mkdir -p /etc/facter/facts.d
 echo 'consul_discovery_token='${consul_discovery_token} > /etc/facter/facts.d/consul.txt
 echo 'current_version='${BUILD_NUMBER} > /etc/facter/facts.d/current_version.txt
 echo 'env='${env} > /etc/facter/facts.d/env.txt

--- a/build_scripts/override_packages.sh
+++ b/build_scripts/override_packages.sh
@@ -23,7 +23,7 @@ if [ -n "${repoconf_repo_source}" ]; then
   # run majic autobuild command to create a pkg repo called foofil
   bash -x ./debian/sync-repo.sh build
   popd
-  sbuild -d trusty -A rjil-cicd_2014.2.179ubuntu1.dsc
+  sbuild -n -d trusty -A rjil-cicd_2014.2.179ubuntu1.dsc
   mkdir new_repo
   cp *.deb new_repo/
   pushd new_repo

--- a/build_scripts/override_packages.sh
+++ b/build_scripts/override_packages.sh
@@ -31,18 +31,3 @@ if [ -n "${repoconf_repo_source}" ]; then
   tar -cvzf ../new_repo.tgz *
   popd
 fi
-
-create_gpg_key() {
-  echo '
-    Key-Type: 1
-    Key-Length: 4096
-    Subkey-Type: ELG-E
-    Subkey-Length: 4096
-    Name-Real: foo repository
-    Expire-Date: 0
-    %%commit
-' > foo
-  gpg --batch --gen-key foo
-  key_id=`gpg --list-keys | grep pub | awk '{print $2}' | awk -F'/' '{print $2}'`
-  gpg --output keyFile --armor --export $key_id
-}

--- a/build_scripts/override_packages.sh
+++ b/build_scripts/override_packages.sh
@@ -23,7 +23,7 @@ if [ -n "${repoconf_repo_source}" ]; then
   # run majic autobuild command to create a pkg repo called foofil
   bash -x ./debian/sync-repo.sh build
   popd
-  sbuild -n -d trusty -A rjil-cicd_2014.2.179ubuntu1.dsc
+  sbuild -n -d trusty -A *.dsc
   mkdir new_repo
   cp *.deb new_repo/
   pushd new_repo

--- a/build_scripts/override_packages.sh
+++ b/build_scripts/override_packages.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+#
+# if the repoconf_repo_source and/or repoconf_source_branch
+# variables are set, it downloads the default.xml file from
+# that remote/branch and uses it to create a package repo
+# called new_repo.tgz. This was written to be integrated
+# with jenkins to archive this repo for uses with jobs
+# that can use that package archive with deploy.sh
+#
+if [ -n "${repoconf_repo_source}" ]; then
+  repo_dir=`pwd`/'pkg_build'
+  mkdir -p $repo_dir
+  git config --global color.ui false
+  pushd $repo_dir
+  if [ -n "${repoconf_source_branch}" ]; then
+    repo init -u $repoconf_repo_source -b $repoconf_source_branch
+  else
+    repo init -u $repoconf_repo_source
+  fi
+  repo sync
+  # run majic autobuild command to create a pkg repo called foofil
+  bash -x ./debian/sync-repo.sh build
+  popd
+  sbuild -d trusty -A rjil-cicd_2014.2.179ubuntu1.dsc
+  mkdir new_repo
+  cp *.deb new_repo/
+  pushd new_repo
+  apt-ftparchive packages . > Packages
+  tar -cvzf ../new_repo.tgz *
+  popd
+fi
+
+create_gpg_key() {
+  echo '
+    Key-Type: 1
+    Key-Length: 4096
+    Subkey-Type: ELG-E
+    Subkey-Length: 4096
+    Name-Real: foo repository
+    Expire-Date: 0
+    %%commit
+' > foo
+  gpg --batch --gen-key foo
+  key_id=`gpg --list-keys | grep pub | awk '{print $2}' | awk -F'/' '{print $2}'`
+  gpg --output keyFile --armor --export $key_id
+}

--- a/manifests/system/apt.pp
+++ b/manifests/system/apt.pp
@@ -50,10 +50,11 @@ class rjil::system::apt (
       origin   => '""',
     }
     apt::source { 'overrides':
-      location    => 'file:/var/lib/jiocloud/overrides',
-      release     => './',
-      repos       => '',
-      include_src => false,
+      location       => 'file:/var/lib/jiocloud/overrides',
+      release        => './',
+      repos          => '',
+      include_src    => false,
+      trusted_source => true,
     }
   }
 

--- a/manifests/system/apt.pp
+++ b/manifests/system/apt.pp
@@ -1,9 +1,16 @@
 ## Class rjil::system::apt
 ## Purpose: configure apt sources
+#
+#
+# == Parameters
+#   [override_repo] specifies the location to an optional override_repo that should be previously set up on disk.
+#     This is intended to be used for cases where you may want to modify and create your own versions of packages
+#     for testing. Defaults to the value of the override_repos fact.
 class rjil::system::apt (
   $enable_puppetlabs = true,
   $proxy             = false,
   $repositories      = {},
+  $override_repo     = $::override_repo,
 ) {
 
   ## two settings to be overrided here in hiera
@@ -22,6 +29,32 @@ class rjil::system::apt (
 
   if $enable_puppetlabs {
     include puppet::repo::puppetlabs
+  }
+
+  if ($override_repo) {
+    file { ['/var/lib/jiocloud', '/var/lib/jiocloud/overrides']:
+      ensure => directory,
+      tag    => 'package',
+    }
+    archive { '/var/lib/jiocloud/overrides/repo.tgz':
+      source       => $override_repo,
+      extract      => true,
+      extract_path => '/var/lib/jiocloud/overrides',
+      tag          => 'package',
+      creates      => '/var/lib/jiocloud/overrides/Packages',
+      before       => Apt::Source['overrides'],
+    }
+    # pin local repos to have the highest priority
+    apt::pin { 'local_repos':
+      priority => '999',
+      origin   => '""',
+    }
+    apt::source { 'overrides':
+      location    => 'file:/var/lib/jiocloud/overrides',
+      release     => './',
+      repos       => '',
+      include_src => false,
+    }
   }
 
   if ($proxy) {

--- a/manifests/tempest.pp
+++ b/manifests/tempest.pp
@@ -140,7 +140,6 @@ class rjil::tempest (
     'python-neutronclient',
     'python-cinderclient',
     'python-heatclient',
-    'oslo.config',
     'python-oslo.config',
     'python-iso8601',
     'python-fixtures',

--- a/manifests/tempest.pp
+++ b/manifests/tempest.pp
@@ -146,6 +146,7 @@ class rjil::tempest (
     'python-testscenarios',
     'python-ecdsa',
     'python-mox3',
+    'testrepository',
     'subunit',
   ])
 

--- a/spec/classes/system/apt_spec.rb
+++ b/spec/classes/system/apt_spec.rb
@@ -44,4 +44,30 @@ describe 'rjil::system::apt' do
     it { should_not contain_apt__source('puppetlabs') }
   end
 
+  describe 'with override repo' do
+    let :params do
+      {
+        'override_repo' => 'http://foo/tar.tgz'
+      }
+    end
+    it 'should contain override resources' do
+      ['/var/lib/jiocloud', '/var/lib/jiocloud/overrides'].each do |x|
+        should contain_file(x).with_ensure('directory')
+      end
+      should contain_archive('/var/lib/jiocloud/overrides/repo.tgz').with({
+        'source'       => 'http://foo/tar.tgz',
+        'extract'      => true,
+        'extract_path' => '/var/lib/jiocloud/overrides',
+        'creates'      => '/var/lib/jiocloud/overrides/Packages',
+        'before'       => 'Apt::Source[overrides]',
+      })
+      should contain_apt__source('overrides').with({
+        'location'    => 'file:/var/lib/jiocloud/overrides',
+        'release'     => './',
+        'repos'       => '',
+        'include_src' => false,
+      })
+    end
+  end
+
 end


### PR DESCRIPTION
This allows users to specify an external location where an
apt repo can be uploaded (like through swift, or on an apache server).

This repo can be downloaded and tested as a part of a normal build.