### PR TITLE
Add missing spec tests for SSL packaging, service tests, blockers etc

### DIFF
--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'hiera-puppet-helper'
+
+describe 'rjil::apache' do
+
+  let :facts do
+    {
+      :operatingsystem        => 'Ubuntu',
+      :operatingsystemrelease => '14.04',
+      :osfamily               => 'Debian',
+      :lsbdistid              => 'ubuntu',
+      :concat_basedir         => '/tmp'
+    }
+  end
+
+  let :hiera_data do
+    {
+      'rjil::apache::ssl'  =>  true,
+    }
+  end
+
+  let :params do
+    {
+      :ssl_secrets_package_name         => 'jiocloud-ssl-certificate',
+      :jiocloud_ssl_cert_package_ensure => 'present',
+    }
+  end
+
+  context 'with ssl enabled' do
+    it do
+      should contain_package('jiocloud-ssl-certificate').that_comes_before('Class[apache]')
+      should contain_class('apache::mod::ssl')
+    end
+  end
+
+  context 'with defaults' do
+    it do
+      should contain_class('apache')
+      should contain_class('apache::mod::rewrite')
+      should contain_class('apache::mod::proxy')
+      should contain_class('apache::mod::proxy_http')
+      should contain_class('apache::mod::headers')
+      should contain_apache__mod('proxy_wstunnel')
+    end
+  end
+end
+

--- a/spec/classes/trust_selfsigned_cert_spec.rb
+++ b/spec/classes/trust_selfsigned_cert_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'hiera-puppet-helper'
+
+describe 'rjil::trust_selfsigned_cert' do
+
+  let :params do
+    {
+      :cert               => '/etc/ssl/certs/jiocloud.com.crt',
+      :ssl_cert_package   => 'jiocloud-ssl-certificate',
+    }
+  end
+
+  let :facts do
+    {
+      :operatingsystem  => 'Ubuntu',
+      :osfamily         => 'Debian',
+      :lsbdsitid        => 'ubuntu',
+    }
+  end
+
+  context 'with defaults' do
+    it do
+      should contain_package('ca-certificates')
+
+      should contain_package('jiocloud-ssl-certificate')
+
+      should contain_file('/usr/local/share/ca-certificates/selfsigned.crt') \
+        .with_ensure('link') \
+        .with_source('/etc/ssl/certs/jiocloud.com.crt') \
+        .that_notifies('Exec[update-cacerts]')
+
+      should contain_exec('update-cacerts') \
+        .with_command('update-ca-certificates --fresh') \
+        .with_refreshonly(true)
+    end
+  end
+end
+

--- a/spec/defines/localuser_spec.rb
+++ b/spec/defines/localuser_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe 'rjil::localuser' do
+  let :facts do
+    {
+      :operatingsystem  => 'Ubuntu',
+      :osfamily         => 'Debian',
+      :lsbdistid        => 'ubuntu',
+    }
+  end
+
+  let (:title)  { 'foouser' }
+
+  context 'with defaults' do
+    let :params do
+      {
+        :name       => 'foouser',
+        :realname   => 'fooname',
+        :sshkeys    => 'abcdefghijklmnopqrstuvwxyz',
+        :shell      => '/bin/bash',
+      }
+    end
+
+    it do
+      should contain_group('foouser').with_ensure('present')
+
+      should contain_user('foouser') \
+        .with_ensure('present') \
+        .with_comment('fooname') \
+        .with_gid('foouser') \
+        .with_groups( ['sudo'] ) \
+        .with_home('/home/foouser') \
+        .with_managehome(true) \
+        .with_membership('minimum') \
+        .with_shell('/bin/bash') \
+        .with_require( ['Group[foouser]'] )
+
+      should contain_file('foouser_sshdir') \
+        .with_group('foouser') \
+        .with_owner('foouser') \
+        .with_mode('0700') \
+        .with_require( ['User[foouser]'] )
+
+      should contain_file('foouser_keys') \
+        .with_content('abcdefghijklmnopqrstuvwxyz') \
+        .with_group('foouser') \
+        .with_mode('0400') \
+        .with_owner('foouser') \
+        .with_require( ['File[foouser_sshdir]'] )
+    end
+  end
+
+end
+

--- a/spec/defines/service_blocker_spec.rb
+++ b/spec/defines/service_blocker_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'rjil::service_blocker' do
+    let :facts do
+      {
+        :operatingsystem => 'Ubuntu',
+        :osfamily        => 'Debian',
+        :lsbdistid       => 'ubuntu',
+      }
+    end
+
+    let (:title)  { 'foo' }
+    context 'with defaults' do
+
+      let :params do
+        {
+          :name       => 'foo',
+          :tries      => 30,
+          :try_sleep  => 20,
+          :datacenter => 'bar',
+        }
+      end
+
+      it do
+        should contain_Dns_blocker('foo.service.bar.consul') \
+          .with_try_sleep('20') \
+          .with_tries('30')
+      end
+
+    end
+end
+

--- a/spec/defines/test_spec.rb
+++ b/spec/defines/test_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'rjil::test' do
+  let :facts do
+    {
+      :operatingsystem => 'Ubuntu',
+      :osfamily        => 'Debian',
+      :lsbdistid       => 'ubuntu',
+    }
+  end
+
+
+  let (:title)  { 'foo' }
+
+  context 'with defaults' do
+    let :params do
+      {
+        :name =>  'foo'
+      }
+    end
+
+    it do
+      should contain_file('/usr/lib/jiocloud/tests/foo') \
+        .with_source('puppet:///modules/rjil/tests/foo') \
+        .with_owner('root') \
+        .with_group('root') \
+        .with_mode('0755')
+    end
+  end
+end
+


### PR DESCRIPTION
This patch adds specs for
- rjil::apache
- rjil::trust_selfsigned_cert
- rjil::localuser
- rjil::service_blocker
- rjil::test