### PR TITLE
Allow httpproxy to be setup as a DNS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,12 @@ Protocol to use when fetching puppet modules. Defaults to `git`.
 export git_protocol=https
 ````
 
+### dns\_override
+
+Provide a DNS server to use during bootstrapping. This will replace the
+contents of /etc/resolv.conf during the bootstrapping process and until
+it is changed back to localhost for consul.
+
 ## Example of a full invocation
 
 This is what I used for testing:

--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -24,6 +24,9 @@ then
   export https_proxy=${env_https_proxy}
   echo https_proxy="'${env_https_proxy}'" >> /etc/environment
 fi
+if [ -n "${dns_override}" ]; then
+  echo 'nameserver ${dns_override}' > /etc/resolv.conf
+fi
 wget -O puppet.deb -t 5 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
 if [ "${env}" == "at" ]
 then

--- a/site.pp
+++ b/site.pp
@@ -190,4 +190,8 @@ node /^uc\d+/ {
 node /^httpproxy\d+/ {
   include rjil::base
   include rjil::http_proxy
+  dnsmasq::conf { 'google':
+    ensure  => present,
+    content => 'server=8.8.8.8',
+  }
 }


### PR DESCRIPTION
This is currently required.