### PR TITLE
Ensure that script fails if any cleanup fails

### DIFF
--- a/files/tests/neutron.sh
+++ b/files/tests/neutron.sh
@@ -14,7 +14,7 @@ if [ -f /root/openrc ]; then
   cleanup_command="neutron net-delete ${netid}"
   neutron subnet-create $netid 10.0.0.0/24 || fail 'neutron subnet-create failed'
   portid=`neutron port-create $netid | grep ' id ' | awk  '{print $4}'` || fail 'neutron port-create failed'
-  cleanup_command="neutron port-delete ${portid} ; ${cleanup_command}"
+  cleanup_command="neutron port-delete ${portid} && ${cleanup_command}"
   eval $cleanup_command || fail "Could not cleanup, retrying"
 else
   echo 'Critical: Openrc does not exist'


### PR DESCRIPTION
Switches from ; to && to ensure that we get an
actual script failure if any of the cleanups fail.