### PR TITLE
ceph/rgw: Fine grained pool creation

### DIFF
--- a/manifests/ceph/mon.pp
+++ b/manifests/ceph/mon.pp
@@ -28,7 +28,12 @@ class rjil::ceph::mon (
   $public_if        = 'eth0',
   $mon_service_name = 'stmon',
   $pools            = ['volumes','backups','images'],
+  $rgw_index_pools  = ['.rgw.root', '.rgw.control', '.rgw.gc', '.users.uid', '.rgw.buckets.index'],
+  $rgw_data_pools   = ['.rgw.buckets'],
   $pool_pg_num      = 128,
+  $index_pool_pg_num= 32,
+  $pool_size  = 3,
+  $data_pool_pg_num = 128,
 ) {
 
 
@@ -62,6 +67,22 @@ class rjil::ceph::mon (
 
   ::ceph::osd::pool{ $pools:
     num_pgs => $pool_pg_num,
+    require => Ceph::Mon[$::hostname],
+  }
+
+  # Create rgw index pools
+  ::ceph::pool{ $rgw_index_pools:
+    pg_num => $index_pool_pg_num,
+    pgp_num => $index_pool_pg_num,
+    size => $pool_size,
+    require => Ceph::Mon[$::hostname],
+  }
+
+  # Create rgw data pools
+  ::ceph::pool{ $rgw_data_pools:
+    pg_num => $data_pool_pg_num,
+    pgp_num => $data_pool_pg_num,
+    size => $pool_size,
     require => Ceph::Mon[$::hostname],
   }
 

--- a/manifests/ceph/mon.pp
+++ b/manifests/ceph/mon.pp
@@ -28,7 +28,7 @@ class rjil::ceph::mon (
   $public_if        = 'eth0',
   $mon_service_name = 'stmon',
   $pools            = ['volumes','backups','images'],
-  $rgw_index_pools  = ['.rgw.root', '.rgw.control', '.rgw.gc', '.users.uid', '.rgw.buckets.index'],
+  $rgw_index_pools  = ['.rgw.root', '.rgw.control', '.rgw.gc', '.rgw', '.users.uid', '.rgw.buckets.index'],
   $rgw_data_pools   = ['.rgw.buckets'],
   $pool_pg_num      = 128,
   $index_pool_pg_num= 32,


### PR DESCRIPTION
We create the pools necessary for radosgw ourselves, this allows us to
control these settings in a more fine grained manner as different pools
can have different pg counts & replica counts. Also fixes #556, as the
new pools modules allows for pg_num to be increased which is a desirable
functionality, the cause of the issue being differing pg/pgp nums for
rgw pools.

Fixes: #556, #487
Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>