### PR TITLE
Adding tmpreaper to clean puppet reports

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -4,6 +4,7 @@
 class rjil::system(
   $proxies                       = {},
   $dhclient_override_domain_name = undef,
+  $puppet_report_keep_hours      = 24,
 ) {
 
   ##
@@ -18,7 +19,21 @@ class rjil::system(
   include rjil::system::apt
   include rjil::system::accounts
 
-  ensure_packages(['molly-guard'])
+  ensure_packages(['molly-guard','tmpreaper'])
+
+  ##
+  # delete puppet reports which are older than $puppet_report_keep_hours hours
+  # Ideally it should have added in tmpreaper daily cron script, but with the
+  # current tmpreaper daily cron script, it is not possible to provide different
+  # timespecs for different directories.
+  # Create a cron to run tmpreaper once every day
+  ##
+  cron {'purge_puppet_reports':
+    command => "tmpreaper -a  ${puppet_report_keep_hours}h /var/lib/puppet/reports/${::fqdn}",
+    user    => root,
+    hour    => 2,
+    minute  => 0
+  }
 
   ##
   # override domain name in dhclient

--- a/spec/classes/system_spec.rb
+++ b/spec/classes/system_spec.rb
@@ -9,6 +9,7 @@ describe 'rjil::system' do
       'lsbdistcodename' => 'trusty',
       'osfamily'        => 'Debian',
       'interfaces'      => 'eth0',
+      'fqdn'            => 'node.local',
     }
   end
 
@@ -37,6 +38,7 @@ describe 'rjil::system' do
       should contain_class('rjil::system::apt')
       should contain_class('rjil::system::accounts')
       should contain_package('molly-guard')
+      should contain_package('tmpreaper')
 
       should contain_file_line('domain_search') \
         .with_path('/etc/resolvconf/resolv.conf.d/base') \
@@ -55,6 +57,15 @@ describe 'rjil::system' do
       should contain_sysctl__value('net.ipv4.conf.default.accept_source_route').with_value(0)
       should contain_sysctl__value('net.ipv4.conf.all.send_redirects').with_value(0)
       should contain_sysctl__value('net.ipv4.conf.default.send_redirects').with_value(0)
+
+      should contain_cron('purge_puppet_reports').with(
+        {
+          :command => 'tmpreaper -a  24h /var/lib/puppet/reports/node.local',
+          :user    => 'root',
+          :hour    => 2,
+          :minute  => 0,
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
One of the reason for disk getting filled is puppet reports, just pushing a
patch to add tmpreaper to purge old puppet reports.