### PR TITLE
move puppet/validation checks to service

### DIFF
--- a/files/maybe-upgrade.sh
+++ b/files/maybe-upgrade.sh
@@ -17,10 +17,10 @@ run_puppet() {
         puppet apply --detailed-exitcodes --logdest=syslog `puppet config print default_manifest`
         # publish the results of that run
         ret_code=$?
-        python -m jiocloud.orchestrate update_own_status puppet $ret_code
+        python -m jiocloud.orchestrate update_own_status puppet_service $ret_code
         if [[ $ret_code = 1 || $ret_code = 4 || $ret_code = 6 ]]; then
                 echo "Puppet failed with return code ${ret_code}, also failing validation"
-                python -m jiocloud.orchestrate update_own_status validation 1
+                python -m jiocloud.orchestrate update_own_status validation_service 1
                 sleep 5
                 exit 1
         fi
@@ -29,7 +29,7 @@ run_puppet() {
 validate_service() {
         run-parts --regex=. --verbose --exit-on-error  --report /usr/lib/jiocloud/tests/
         ret_code=$?
-        python -m jiocloud.orchestrate update_own_status validation $ret_code
+        python -m jiocloud.orchestrate update_own_status validation_service $ret_code
         if [[ $ret_code != 0 ]]; then
                 echo "Validation failed with return code ${ret_code}"
                 sleep 5

--- a/manifests/jiocloud/consul.pp
+++ b/manifests/jiocloud/consul.pp
@@ -9,16 +9,18 @@ class rjil::jiocloud::consul($config_hash) {
   }
 
   class { '::consul':
-    install_method => 'package',
-    ui_package_name => 'consul-web-ui',
+    install_method    => 'package',
+    ui_package_name   => 'consul-web-ui',
     ui_package_ensure => 'absent',
-    bin_dir => '/usr/bin',
-    config_hash => $config_hash,
+    bin_dir           => '/usr/bin',
+    config_hash       => $config_hash,
+    purge_config_dir  => true,
   }
   exec { "reload-consul":
     command     => "/usr/bin/consul reload",
     refreshonly => true,
     subscribe   => Service['consul'],
   }
+  File['/etc/consul'] ~> Exec['reload-consul']
 
 }

--- a/manifests/jiocloud/consul/base_checks.pp
+++ b/manifests/jiocloud/consul/base_checks.pp
@@ -3,21 +3,20 @@
 # Setup Validation checks for Puppet runs
 #
 class rjil::jiocloud::consul::base_checks(
-  # default to 5 days
-  $puppet_ttl       = '7200m',
-  $validation_ttl   = '7200m',
-  $puppet_notes     = 'Status of Puppet run',
-  $validation_notes = 'Status of configuration validation checks'
+  # default to 24 hours
+  $puppet_ttl       = '1440m',
+  # default to one hour
+  $validation_ttl   = '60m',
 ) {
 
-  consul::check { 'puppet':
-    ttl   => $puppet_ttl,
-    notes => $puppet_notes,
+  rjil::jiocloud::consul::service { 'puppet':
+    check_command => false,
+    ttl           => $puppet_ttl,
   }
 
-  consul::check { 'validation':
-    ttl   => $validation_ttl,
-    notes => $validation_notes,
+  rjil::jiocloud::consul::service { 'validation':
+    check_command => false,
+    ttl           => $validation_ttl,
   }
 
 }

--- a/manifests/jiocloud/consul/service.pp
+++ b/manifests/jiocloud/consul/service.pp
@@ -2,17 +2,29 @@ define rjil::jiocloud::consul::service(
   $port          = 0,
   $check_command = "/usr/lib/jiocloud/tests/service_checks/${name}.sh",
   $interval      = '10s',
+  $ttl           = false,
   $tags          = [],
 ) {
+
+  if $check_command {
+    $check = {
+      script => $check_command,
+      interval => $interval
+    }
+  } elsif $ttl {
+    $check = {
+      ttl => $ttl,
+    }
+  } else {
+    fail("Must specify either ttl or check_command")
+  }
+
   $service_hash = {
     service => {
       name  => $name,
       port  => $port + 0,
       tags  => $tags,
-      check => {
-        script => $check_command,
-        interval => $interval
-      }
+      check => $check,
     }
   }
 

--- a/spec/classes/consul_base_check_spec.rb
+++ b/spec/classes/consul_base_check_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'rjil::jiocloud::consul::base_checks' do
+
+  it 'should configure base checks' do
+    should contain_rjil__jiocloud__consul__service('puppet').with({
+      'check_command' => false,
+      'ttl'           => '1440m'
+    })
+    should contain_rjil__jiocloud__consul__service('validation').with({
+      'check_command' => false,
+      'ttl'           => '60m'
+    })
+  end
+end

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe 'rjil::jiocloud::consul::service' do
+
+  let :title do
+    'foo'
+  end
+
+  describe 'with defaults' do
+    it 'should contain defaults' do
+      should contain_file('/etc/consul').with_ensure('directory')
+      should contain_file('/etc/consul/foo.json').with({
+        'ensure'  => 'present',
+        'content' =>
+'{
+  "service": {
+    "name": "foo",
+    "port": 0,
+    "tags": [
+
+    ],
+    "check": {
+      "script": "/usr/lib/jiocloud/tests/service_checks/foo.sh",
+      "interval": "10s"
+    }
+  }
+}
+'
+      })
+    end
+  end
+  describe 'when setting ttl' do
+    it { should contain_file('/etc/consul/foo.json').with({
+        'ensure'  => 'present',
+        'content' =>
+'{
+  "service": {
+    "name": "foo",
+    "port": 0,
+    "tags": [
+
+    ],
+    "check": {
+      "script": "/usr/lib/jiocloud/tests/service_checks/foo.sh",
+      "interval": "10s"
+    }
+  }
+}
+'
+    })}
+
+  end
+
+end


### PR DESCRIPTION
this patch moves puppet/validation checks to
services so that their failures due to ttls
do not cause node outages.