### PR TITLE
Limit number of snapshots to 240 per customer account

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -300,6 +300,7 @@ cinder::volume::rbd::volume_tmp_dir: /tmp
 cinder::volume::rbd::rbd_secret_uuid: "%{hiera('cinder_rbd_secret_uuid')}"
 cinder::glance::glance_api_servers: "%{hiera('api_protocol')}://%{hiera('glance_public_address')}:%{hiera('glance_api_port')}"
 cinder::quota::quota_volumes: 120
+cinder::quota::quota_snapshots: 240
 
 ########### Nova config
 ###################################

--- a/manifests/cinder.pp
+++ b/manifests/cinder.pp
@@ -64,6 +64,7 @@ class rjil::cinder (
   $volume_nofile           = 10240,
   $rewrites                = undef,
   $headers                 = undef,
+  $use_default_quota_class = false,
 ) {
 
   ######################## Service Blockers and Ordering
@@ -109,6 +110,11 @@ class rjil::cinder (
   ##
 
   cinder_config { 'DEFAULT/osapi_volume_listen_port': value => $localbind_port }
+
+  ##
+  # Cinder default quotas read from the config file.
+
+  cinder_config { 'DEFAULT/use_default_quota_class': value => $use_default_quota_class }
 
   ## Configure apache reverse proxy
   apache::vhost { 'cinder':


### PR DESCRIPTION
Fix https://bugs.launchpad.net/jio/+bug/1454072

Closes-bug: #1454072