### PR TITLE
Use old version of openstacklib to fix the failures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -73,7 +73,7 @@ fixtures:
       repo: https://github.com/stackforge/puppet-cinder
       ref: 4.0.0
     openstacklib:
-      repo: https://github.com/stackforge/puppet-openstacklib
+      repo: https://github.com/jiocloud/puppet-openstacklib
       ref: origin/master
     ironic:
       repo: https://github.com/stackforge/puppet-ironic


### PR DESCRIPTION
Changed .fixtures.yml to use jiocloud fork or openstacklib
    
    We were using openstacklib module from stackforge for travis, and openstacklib
    have changed the way they handle the openstack auth for openstack
    client based providers which affect us. Also we use jiocloud fork in Puppetfile.
    So changing it to jiocloud fork for travis also.