### PR TITLE
UC| Use interface and ip address based on the subnet

### DIFF
--- a/hiera/data/cloud_provider/hp.yaml
+++ b/hiera/data/cloud_provider/hp.yaml
@@ -1,8 +1,3 @@
-public_address: "%{ipaddress_eth0}"
-public_interface: eth0
-private_address: "%{ipaddress_vhost0_or_eth0}"
-private_interface: eth0
-
 rjil::system::proxies:
   "no":
     url: "127.0.0.1,169.254.169.254,localhost,consul,jiocloud.com"

--- a/hiera/data/cloud_provider/jio.yaml
+++ b/hiera/data/cloud_provider/jio.yaml
@@ -1,8 +1,3 @@
-public_address: "%{ipaddress_eth0}"
-public_interface: eth0
-private_address: "%{ipaddress_eth0}"
-private_interface: eth0
-
 rjil::system::proxies:
   "no":
     url: "127.0.0.1,169.254.169.254,localhost,consul,jiocloud.com"

--- a/hiera/data/cloud_provider/jio_staging.yaml
+++ b/hiera/data/cloud_provider/jio_staging.yaml
@@ -1,8 +1,3 @@
-public_address: "%{ipaddress_eth0}"
-public_interface: eth0
-private_address: "%{ipaddress_eth0}"
-private_interface: eth0
-
 rjil::system::proxies:
   "no":
     url: "127.0.0.1,169.254.169.254,localhost,consul,jiocloud.com"

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -655,17 +655,6 @@ contrail::vrouter::debug: true
 
 rjil::contrail::server::enable_analytics: false
 
-##
-# Adding common setting for contrail::interface, this may need to be override in
-# environment specific interface
-# contrail::interface must be the interface which is dedicated for VM network -
-# in case of two NIC scenario on openstack nodes (Compute, control etc), one nic would be dedicated for control plane,
-# storage access etc (private) and other would be used for SDN (VM communication
-# - public).
-##
-contrail::interface: "%{hiera('public_interface')}"
-contrail::vrouter::vrouter_physical_interface: "%{hiera('contrail::interface')}"
-
 contrail::config::quota_floating_ip: 5
 contrail::config::quota_logical_router: 10
 contrail::config::quota_security_group: 100

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -6,10 +6,17 @@
 # Idea is to enable jumbo frames after completing initial setup.
 ##
 mtu: 1500
-public_address: "%{ipaddress_eth0}"
-public_interface: eth0
-private_address: "%{ipaddress_eth0}"
-private_interface: eth0
+##
+# instead of assuming the ipaddess will be on specific network interface, just
+# provide the network in the format <network with dot replaced with>_<cidr>
+# This will avoid issues on using different nic on the servers because of any
+# reasons like nic port failures. It also fix the problem of the ip address
+# being moved to vhost0 interface in compute node.
+##
+public_address: "%{ipaddress_10_0_0_0_16}"
+public_interface: "%{interface_10_0_0_0_16}"
+private_address: "%{ipaddress_10_0_0_0_16}"
+private_interface: "%{interface_10_0_0_0_16}"
 
 ###################################
 ########  Database config #########

--- a/hiera/data/env/at.yaml
+++ b/hiera/data/env/at.yaml
@@ -1,6 +1,7 @@
 rustedhalo_apt_repo_release: 'trusty-testing'
 
 rjil::jiocloud::consul::encrypt: "%{consul_gossip_encrypt}"
+contrail::vrouter::vrouter_physical_interface: eth0
 
 rjil::ceph::osd::autogenerate: true
 rjil::ceph::osd::autodisk_size: 10

--- a/hiera/data/env/gate.yaml
+++ b/hiera/data/env/gate.yaml
@@ -1,5 +1,7 @@
 rustedhalo_apt_repo_release: 'trusty-unstable'
 
+contrail::vrouter::vrouter_physical_interface: eth0
+
 rjil::ceph::osd::autogenerate: true
 rjil::ceph::osd::autodisk_size: 10
 rjil::ceph::osd::osd_journal_size: 2

--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -1,8 +1,3 @@
-public_address: "%{ipaddress_eth1}"
-public_interface: eth1
-private_address: "%{ipaddress_vhost0_or_eth1}"
-private_interface: eth1
-
 rjil::ceph::osd::autogenerate: true
 rjil::ceph::osd::autodisk_size: 10
 rjil::ceph::osd::osd_journal_size: 2

--- a/lib/facter/ipaddress_vhost0_or_eth0.rb
+++ b/lib/facter/ipaddress_vhost0_or_eth0.rb
@@ -1,5 +1,0 @@
-Facter.add(:ipaddress_vhost0_or_eth0) do
-  setcode do
-    Facter.value(:ipaddress_vhost0) || Facter.value(:ipaddress_eth0)
-  end
-end

--- a/lib/facter/ipaddress_vhost0_or_eth1.rb
+++ b/lib/facter/ipaddress_vhost0_or_eth1.rb
@@ -1,5 +1,0 @@
-Facter.add(:ipaddress_vhost0_or_eth1) do
-  setcode do
-    Facter.value(:ipaddress_vhost0) || Facter.value(:ipaddress_eth1)
-  end
-end

--- a/lib/facter/jiocloud_network.rb
+++ b/lib/facter/jiocloud_network.rb
@@ -1,0 +1,32 @@
+##
+# Custom fact for ipaddress and interface based on network and netmask
+# This will help to configure ipaddress and interfaces for various services
+# without assuming IP address on specific interface.
+# If the machine have 2 nics with network 192.168.0.0/24 and 10.0.0.0/8, this
+# code will create facts like below with appropriate values.
+# ipaddress_192_168_0_0_24, interface_192_168_0_0_24,
+# ipaddress_10.0.0.0_24, interface_10.0.0.0_24
+##
+require 'ipaddr'
+Facter.value('interfaces').split(',').reject{ |r| r == 'lo' }.each do |iface|
+  ipaddress = Facter.value('ipaddress_' + iface)
+  if ipaddress
+    ##
+    # converting netmask to cidr, so that providing fact name would be easier
+    # - rather than typing ipaddress_192_168_0_0_255_255_255_0 just type
+    # 192_168_0_0_24 (<network>_<cidr>)
+    ##
+    cidr = IPAddr.new(Facter.value('netmask_' + iface)).to_i.to_s(2).count("1").to_s
+    network = Facter.value('network_' + iface).gsub('.', '_')
+    Facter.add('ipaddress_' + network + '_' + cidr) do
+      setcode do
+        ipaddress
+      end
+    end
+    Facter.add('interface_' + network + '_' + cidr) do
+      setcode do
+        iface
+      end
+    end
+  end
+end

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -18,5 +18,28 @@ class rjil::base (
   if $self_signed_cert {
     include rjil::trust_selfsigned_cert
   }
+
+  ##
+  # New kind of ipaddress and interface facts (ipaddress and interface based on
+  # subnet assigned to them) are raising new problem - in case
+  # of a misconfiguration of subnets, those facts can return null values for
+  # those facts. In that case, puppet run should explicitely fail to avoid the
+  # system to go into invalid state.
+  # NOTE: This code assume the fact is only used for private_address,
+  # public_address, private_interface, public_interface. If in future those
+  # facts used for anything else, they must be validated either here or in
+  # appropriate code.
+  ##
+
+  if ! hiera('private_address') {
+    fail("hiera data for 'private_address' is not known")
+  } elsif ! hiera('private_interface') {
+    fail("Hiera data for 'private_interface' is not known")
+  } elsif ! hiera('public_address') {
+    fail("hiera data for 'public_address' is not known")
+  } elsif ! hiera('public_interface') {
+    fail("Hiera data for 'public_interface' is not known")
+  }
+
 }
 


### PR DESCRIPTION
NOTE NOTE NOTE! THIS PATCH NEED CHANGES IN PRODUCTION HIERA (contrail::vrouter::vrouter_physical_interface to be added/changed)

Currently we assume that the ip address we need to configure in the cloud is
always setup on same interface on a specific set of servers/cloud provider,
which can be incorrect because of number of reasons
1. what if we had to use different nic port because of one bad port
2. compute node have the ip of physical interface will be moved to vhost0 in
which case you need special consideration - like custom facts

Rather the subnet is more consistent, this patch adds code to create custom
facts for ipaddress and interface based on subnet like interface_10_0_0_0_8 with
value eth0 in case eth0 have subnet configured 10.0.0.0/8.

This will allow us to use the fact ipaddress_{subnet} and interface_{subnet}
whereever required, as far as correct subnet provided, this will provide
consistant network config across the servers.

This should fix the issue #643.
