### PR TITLE
Adding role specific override per environments

### DIFF
--- a/hiera/hiera.yaml
+++ b/hiera/hiera.yaml
@@ -7,6 +7,7 @@
 :hierarchy:
   - "clientcert/%{::clientcert}"
   - "secrets/%{env}"
+  - "role/%{env}/%{jiocloud_role}"
   - "role/%{jiocloud_role}"
   - "hw/%{cloud_provider}/%{productname}"
   - "cloud_provider/%{cloud_provider}"


### PR DESCRIPTION
Currently if we wanted to override things per role in specific environment, it
is not possible (say i need to override a setting on ct role in production). So
adding a role specific override per environments.