### PR TITLE
Fixed ssh_config filename in test.sh

### DIFF
--- a/build_scripts/test.sh
+++ b/build_scripts/test.sh
@@ -6,4 +6,4 @@ if [ ! -f ${project_tag}_ssh_config ]; then
   python -m jiocloud.apply_resources ssh_config --project_tag=${project_tag} ${mappings_arg} environment/${layout:-full}.yaml > ${project_tag}_ssh_config
 fi
 
-ssh -F ssh_config -l ${ssh_user:-jenkins} gcp1_${project_tag} '~jenkins/tempest/run_tempest.sh -N -- --load-list ~jenkins/tempest_tests.txt'
+ssh -F ${project_tag}_ssh_config -l ${ssh_user:-jenkins} gcp1_${project_tag} '~jenkins/tempest/run_tempest.sh -N -- --load-list ~jenkins/tempest_tests.txt'


### PR DESCRIPTION
test.sh create ssh config file as ${project_tag}_ssh_config, but ssh to run
tempest run is using ssh_config (old one), which was missed to update, fixed it.