### PR TITLE
Use appropriate neutron service password for tempest provision

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -864,7 +864,7 @@ rjil::tempest::tempest_clone_path: "%{hiera('tempest::tempest_clone_path')}"
 rjil::tempest::provision::auth_host: "%{hiera('keystone_public_address')}"
 rjil::tempest::provision::auth_port: "%{hiera('keystone_port')}"
 rjil::tempest::provision::auth_protocol: "%{hiera('api_protocol')}"
-
+rjil::tempest::provision::neutron_admin_password: "%{hiera('neutron::keystone::auth::password')}"
 
 tempest::provision::imagename: "%{hiera('tempest::image_name')}"
 tempest::provision::tenantname: "%{hiera('tempest::tenant_name')}"


### PR DESCRIPTION
This patch will make sure changing neutron::keystone::auth::password will change
neutron_config for tempest_provision also.