### PR TITLE
Sudo with different capabilities

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -550,7 +550,9 @@ rjil::system::dhclient_override_domain_name: node.consul
 ############################
 
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins, consul]
-rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins, consul]
+rjil::system::accounts::sudo_users:
+  admin:
+    users: [soren,bodepd,hkumar,jenkins, consul]
 
 ########### Apt settings
 ############################

--- a/hiera/data/env/at.yaml
+++ b/hiera/data/env/at.yaml
@@ -8,7 +8,9 @@ rjil::ceph::osd::osd_journal_size: 2
 nova::compute::libvirt::libvirt_virt_type: qemu
 
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,alokjani,amar,ynshenoy,abhishekl,mayankkapoor,soumit,anshup,varunarya,prashant,punituee,saju,ajayaa,swami,karansa,abhidixit,shashankchakelam,vpramo,atmesh.mishra,prashant.chawla]
-rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,alokjani,amar,ynshenoy,abhishekl,mayankkapoor,soumit,anshup,varunarya,prashant,punituee,saju,ajayaa,swami,karansa,abhidixit,shashankchakelam,vpramo,atmesh.mishra,prashant.chawla]
+rjil::system::accounts::sudo_users:
+  admin:
+    users: [soren,bodepd,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,alokjani,amar,ynshenoy,abhishekl,mayankkapoor,soumit,anshup,varunarya,prashant,punituee,saju,ajayaa,swami,karansa,abhidixit,shashankchakelam,vpramo,atmesh.mishra,prashant.chawla]
 
 rjil::base::self_signed_cert: true
 

--- a/hiera/data/env/gate.yaml
+++ b/hiera/data/env/gate.yaml
@@ -8,7 +8,10 @@ rjil::ceph::osd::osd_journal_size: 2
 nova::compute::libvirt::libvirt_virt_type: qemu
 
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet]
-rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet]
+rjil::system::accounts::sudo_users:
+  admin:
+    users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet]
+
 rjil::base::self_signed_cert: true
 
 tempest::admin_password: tempest_admin

--- a/manifests/system/accounts.pp
+++ b/manifests/system/accounts.pp
@@ -38,12 +38,7 @@ class rjil::system::accounts (
     config_file_replace => false,
   }
 
-  ## Make an intersection of active users and sudo users,
-  ##  so that sudo_users are always a subset of active_users
-
-  $sudo_users_orig = intersection($active_users,$sudo_users)
-
-  rjil::system::accounts::sudo_conf { $sudo_users_orig: }
+  create_resources('rjil::system::accounts::sudo', $sudo_users, {active_users => $active_users})
 
   rjil::jiocloud::consul::service { "ssh":
     port          => 22,

--- a/manifests/system/accounts/sudo.pp
+++ b/manifests/system/accounts/sudo.pp
@@ -1,0 +1,20 @@
+# Define rjil::system::accounts::sudo
+#
+# == Purpose
+# Call rjil::system::accounts::sudo::conf with appropriate params
+
+define rjil::system::accounts::sudo (
+  $active_users     = [],
+  $users            = [],
+  $commands_allowed = [],
+) {
+
+  ## Make an intersection of active users and sudo users,
+  ##  so that sudo_users are always a subset of active_users
+
+  $sudo_users = intersection($active_users,$users)
+
+  ::rjil::system::accounts::sudo::conf { $sudo_users:
+    commands_allowed => $commands_allowed,
+  }
+}

--- a/manifests/system/accounts/sudo/conf.pp
+++ b/manifests/system/accounts/sudo/conf.pp
@@ -1,0 +1,28 @@
+# Define rjil::system::accounts::sudo::conf
+# Purpose
+# Generates sudoers files under /etc/sudoers.d/, one per user
+
+define rjil::system::accounts::sudo::conf (
+  $user             = $name,
+  $commands_allowed = [],
+) {
+
+  $cmdalias_name_uc = upcase($user)
+
+  ##
+  # empty array in commands allowed means all commands are allowed (isn't it okay?)
+  ##
+  if empty($commands_allowed) {
+    $sudo_conf = "#Managed By Puppet\n${user} ALL=(ALL) NOPASSWD: ALL"
+  } else {
+    $commands_allowed_list = join($commands_allowed,',')
+
+    $sudo_conf = "#Managed By Puppet
+Cmnd_Alias CMND_${cmdalias_name_uc} = ${commands_allowed_list}
+${user} ALL=(ALL) NOPASSWD: CMND_${cmdalias_name_uc}"
+  }
+
+  ::sudo::conf { $user:
+    content  => $sudo_conf,
+  }
+}

--- a/manifests/system/accounts/sudo_conf.pp
+++ b/manifests/system/accounts/sudo_conf.pp
@@ -1,9 +1,0 @@
-## Define rjil::system::accounts::sudo_conf
-## Purpose
-## Generates sudoers files under /etc/sudoers.d/, one per user
-
-define rjil::system::accounts::sudo_conf {
-  ::sudo::conf { $name:
-    content  => "#Managed By Puppet\n${name} ALL=(ALL) NOPASSWD: ALL",
-  }
-}

--- a/spec/classes/system_spec.rb
+++ b/spec/classes/system_spec.rb
@@ -21,7 +21,11 @@ describe 'rjil::system' do
           'u3' => {'realname' => 'u3', 'sshkeys' => 'ssh-dsskey'},
         },
       'rjil::system::accounts::active_users' => ['u2','u3'],
-      'rjil::system::accounts::sudo_users' => ['u3'],
+      'rjil::system::accounts::sudo_users' => {'admin' =>
+                                                {
+                                                  'users' => ['u3'],
+                                                }
+                                              },
       'ntp::servers' => ['server1']
     }
   end


### PR DESCRIPTION
    This patch enable to create sudo users with different capabilities, It
    support adding hiera data with different set of users with different commands
    allowed.
    
    e.g below hiera data will create two sets of users, - admin1 and admin2 with all
    access and user1 and user2 with access to commands cat and less.
    ```
    rjil::system::accounts::sudo_users:
      admin:
        users: [admin1,admin2]
      readonly:
        users: [user1,user2]
        commands_allowed: ['/bin/cat','/usr/bin/less']
    ```
    
    Appends username to command alias to prevent errors when there are multiple
    non-admin users.