### PR TITLE
rjil::test::check changes

### DIFF
--- a/manifests/test/check.pp
+++ b/manifests/test/check.pp
@@ -4,15 +4,24 @@
 #
 
 define rjil::test::check(
-  $port    = 0,
-  $address = '127.0.0.1',
-  $ssl     = false,
-  $type    = 'http',
+  $port       = 0,
+  $address    = '127.0.0.1',
+  $ssl        = false,
+  $type       = 'http',
+  $check_type = 'service',
 ) {
 
   include rjil::test::base
 
-  file { "/usr/lib/jiocloud/tests/service_checks/${name}.sh":
+  if $check_type == 'service' {
+    $test_file = "/usr/lib/jiocloud/tests/service_checks/${name}.sh"
+  } elsif $check_type == 'validation' {
+    $test_file = "/usr/lib/jiocloud/tests/${name}.sh"
+  } else {
+    fail("Invalid check_type - $check_type)")
+  }
+
+  file { $test_file:
     content => template("rjil/tests/${type}_check.sh.erb"),
     owner   => 'root',
     group   => 'root',

--- a/spec/defines/test_check_spec.rb
+++ b/spec/defines/test_check_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe 'rjil::test::check' do
+  let :facts do
+    {
+      :operatingsystem => 'Ubuntu',
+      :osfamily        => 'Debian',
+      :lsbdistid       => 'ubuntu',
+    }
+  end
+
+
+  let (:title)  { 'foo' }
+
+  context 'with http port' do
+    let :params do
+      {
+        :name => 'foo',
+        :port => 80,
+      }
+    end
+
+    it 'should create an http based service check' do
+      should contain_class('rjil::test::base')
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/foo.sh') \
+        .with_content(/\/usr\/lib\/nagios\/plugins\/check_http -H 127.0.0.1 -p 80/) \
+        .with_owner('root') \
+        .with_group('root') \
+        .with_mode('0755')
+    end
+  end
+
+  context 'with https' do
+    let :params do       
+      {                  
+        :name => 'foo',  
+        :ssl  => true,
+        :port => 80,     
+      }                  
+    end
+
+    it 'should create an https service check' do
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/foo.sh') \
+        .with_content(/\/usr\/lib\/nagios\/plugins\/check_http -S -H 127.0.0.1 -p 80/)
+    end
+  end
+
+  context 'with tcp' do
+    let :params do     
+      {                
+        :name => 'foo',
+        :type => 'tcp',
+        :port => 80,   
+      }                
+    end
+
+    it 'should create an tcp service check' do
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/foo.sh') \
+        .with_content(/\/usr\/lib\/nagios\/plugins\/check_tcp -H 127.0.0.1 -p 80/)
+    end
+  end
+
+  context 'with udp' do
+    let :params do      
+      {                 
+        :name    => 'foo', 
+        :type    => 'udp',
+        :address => '10.1.0.1',
+        :port    => 80, 
+      }                 
+    end                 
+     
+    it 'should create a udp service check with provided address' do
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/foo.sh') \
+        .with_content(/netcat -z -v -u 10.1.0.1  80/)
+    end
+  end
+
+  context 'with proc' do
+    let :params do
+      {
+        :name => 'foo',
+        :type => 'proc',
+      }
+    end
+     
+    it 'should create a process service check' do
+      should contain_file('/usr/lib/jiocloud/tests/service_checks/foo.sh') \
+        .with_content(/\/usr\/lib\/nagios\/plugins\/check_killall_0 foo/)
+    end
+  end
+
+  context 'with validation process check' do
+    let :params do                          
+      {                                     
+        :name       => 'foo',                     
+        :type       => 'proc',                    
+        :check_type => 'validation',
+      }                                     
+    end                                     
+     
+    it 'should create a process validation check' do   
+      should contain_file('/usr/lib/jiocloud/tests/foo.sh') \
+        .with_content(/\/usr\/lib\/nagios\/plugins\/check_killall_0 foo/)
+    end
+  end
+
+  context 'with random check_type' do
+    let :params do                    
+      {                               
+        :name       => 'foo',         
+        :type       => 'proc',        
+        :check_type => 'blah', 
+      }                               
+    end
+
+    it 'should error out' do
+      expect {
+        should compile
+      }.to raise_error(Puppet::Error, /Invalid check_type - blah/)
+    end
+  end
+end
+

--- a/templates/tests/udp_check.sh.erb
+++ b/templates/tests/udp_check.sh.erb
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+netcat -z -v -u <%= @address %>  <%= @port %>


### PR DESCRIPTION
This patch:
* Added a parameter to rjil::test::check to use it for both service and
 validation checks
* Added a udp port check script template using netcat - nagios check_udp doesnt
 work as expected

This would be using in undercloud controller, just pushing it as separate pr, if we wanted to test it separately.