### PR TITLE
Disable execution of ntpdate on ntp server

### DIFF
--- a/hiera/data/role/bootstrap.yaml
+++ b/hiera/data/role/bootstrap.yaml
@@ -1,6 +1,7 @@
 rjil::jiocloud::consul_role: bootstrapserver
 # etcd serves as the ntp server
 rjil::system::ntp::server: true
+rjil::system::ntp::run_ntpdate: false
 
 ntp::servers: "%{lookup_array('upstream_ntp_servers')}"
 ntp::udlc: yes


### PR DESCRIPTION
Sometimes ntpdate to pool.ntp.org is keep on failing, which is causing the
entire build failing, This patch is to disable ntpdate on local ntp server which
should not cause any issues as other nodes are syncing the time from this
server and until ntp server get the time from remote clock, it will use local
clock, so still all nodes in the build will have clock synced.

This solve issue #663.