### PR TITLE
vrouter logrotate fix

### DIFF
--- a/files/contrail-consolidate-logs.sh
+++ b/files/contrail-consolidate-logs.sh
@@ -12,7 +12,6 @@
 
 contrail_logs=('contrail-api'
 		'contrail-schema'
-		'contrail-vrouter'
 		'contrail-discovery'
 		'contrail-collector'
 		'vnc_openstack.err'

--- a/manifests/contrail/vrouter.pp
+++ b/manifests/contrail/vrouter.pp
@@ -43,8 +43,10 @@ class rjil::contrail::vrouter (
 
   include rjil::contrail::logrotate::consolidate
 
-  rjil::jiocloud::logrotate { 'contrail-vrouter-daily.log':
+# Vrouter is now honoring the filesize, so no need for consolidate here
+  rjil::jiocloud::logrotate { 'contrail-vrouter':
     logdir       => '/var/log/contrail',
+    copytruncate => true,
   }
   
   ##


### PR DESCRIPTION
 Vrouter is now honoring the filesize, so no need for consolidate for it anymore. 