### PR TITLE
UC| Made rjil::nova::compute more generic to use in different scenarios

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -367,9 +367,8 @@ nova::compute::libvirt::libvirt_images_type: raw
 
 nova::compute::neutron::libvirt_vif_driver: nova_contrail_vif.contrailvif.VRouterVIFDriver
 
-
-rjil::nova::compute::cinder_rbd_secret_uuid: "%{hiera('cinder_rbd_secret_uuid')}"
-rjil::nova::compute::ceph_mon_key: "%{hiera('rjil::ceph::mon::key')}"
+rjil::nova::compute::rbd::cinder_rbd_secret_uuid: "%{hiera('cinder_rbd_secret_uuid')}"
+rjil::nova::compute::rbd::ceph_mon_key: "%{hiera('rjil::ceph::mon::key')}"
 
 rjil::nova::controller::nova_auth:
   username: nova

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -1,14 +1,29 @@
+#
 # Class: rjil::nova::compute
-##
+#
+# == Description: Setup nova compute
+#
+# == Parameters
+#
+# [*rbd_enabled*]
+#   whether rbd is enabled or not, if rbd is enabled, ceph specific
+#   configurations would be added.
+#
+# [*consul_check_interval*]
+#   Consul service health check interval
+#
+# [*private_interface*]
+#   Private interface on which compute listen for vncserver
+#
+# [*compute_driver*]
+#   Which compute driver to be used, example: libvirt, ironic. Default: libvirt.
+#
+
 class rjil::nova::compute (
-  $ceph_mon_key,
-  $cinder_rbd_secret_uuid,
-  $ceph_keyring_file_owner    = 'nova',
-  $ceph_keyring_path          = '/etc/ceph/keyring.ceph.client.cinder_volume',
-  $ceph_keyring_cap           = 'mon "allow r" osd "allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rx pool=images"',
-  $rbd_user                   = 'cinder_volume',
-  $nova_snapshot_image_format = 'qcow2',
-  $consul_check_interval      = '120s',
+  $rbd_enabled           = true,
+  $consul_check_interval = '120s',
+  $private_address       = $::ipaddress,
+  $compute_driver        = 'libvirt',
 ) {
 
   #
@@ -17,58 +32,32 @@ class rjil::nova::compute (
 
   include rjil::test::compute
 
-
-  ##
-  # service blocker to stmon before mon_config to be run.
-  # Mon_config must be run on all ceph client nodes also.
-  # Also mon_config should be setup before cinder_volume to be started,
-  #   as ceph configuration is required cinder_volume to function.
-  ##
-
-  ensure_resource('rjil::service_blocker', 'stmon', {})
-  Rjil::Service_blocker['stmon']  ->
-  Class['rjil::ceph::mon_config'] ->
-  Ceph::Conf::Clients['cinder_volume'] ->
-  Exec['secret_set_value_cinder_volume']
-
-
-  ##
-  # This will fix the failure on puppet first run.
-  ##
-  Ceph::Conf::Mon_config<||> ->
-  Exec['secret_set_value_cinder_volume']
-
-  Class['::nova'] ->
-  Ceph::Auth['cinder_volume']
-
-  Package['libvirt'] ->
-  Exec['secret_define_cinder_volume']
-
-  Package['libvirt'] ->
-  Exec['rm_virbr0']
-
   ensure_resource('package','python-six', { ensure => 'latest' })
 
-  ##
-  # Hardcoding private/public ipaddress/interface will not work in case of
-  # compute node, the IP address will be moved to vhost0 So adding a variable
-  # to get interface details by running the function first_interface_with_ip.
-  ##
-
-  $usable_ipaddress = first_interface_with_ip('ipaddress',"${private_interface},vhost0")
-
-
-  include ::ceph::conf
-  include rjil::ceph::mon_config
   include rjil::nova::zmq_config
   include ::nova::client
   include ::nova
-  class {'::nova::compute':
-    vncserver_proxyclient_address => $usable_ipaddress
-  }
-  include ::nova::compute::libvirt
-  include ::nova::compute::neutron
+  include ::nova::compute
   include ::nova::network::neutron
+
+  ##
+  # call compute driver specific classes
+  ##
+  include "::nova::compute::${compute_driver}"
+
+  ##
+  # ironic doesnt need vif specific configurations.
+  ##
+  if $compute_driver != 'ironic' {
+    include ::nova::compute::neutron
+  }
+
+  ##
+  # if rbd is enabled, configure ceph
+  ##
+  if $rbd_enabled {
+    include ::rjil::nova::compute::rbd
+  }
 
   rjil::jiocloud::logrotate { 'nova-compute':
     logdir => '/var/log/nova/'
@@ -77,54 +66,12 @@ class rjil::nova::compute (
   include rjil::nova::logrotate::manage
 
   ##
-  # Add ceph keyring for cinder_volume. This is required cinder to connect to
-  # ceph.
-  ##
-
-  ::ceph::auth {'cinder_volume':
-    mon_key      => $ceph_mon_key,
-    client       => $rbd_user,
-    file_owner   => $ceph_keyring_file_owner,
-    keyring_path => $ceph_keyring_path,
-    cap          => $ceph_keyring_cap,
-  }
-
-
-  ##
   # Remove libvirt default nated network
   ##
   exec { 'rm_virbr0':
-    command => "virsh net-destroy default && virsh net-undefine default",
-    path    => "/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin",
-    onlyif  => "virsh -q net-list | grep -q default" ,
-  }
-
-  ##
-  # Add ceph configuration for cinder_volume. This is required to find keyring
-  # path while connecting to ceph as cinder_volume.
-  ##
-  ::ceph::conf::clients {'cinder_volume':
-    keyring => $ceph_keyring_path,
-  }
-
-
-  exec { "secret_define_cinder_volume":
-    command => "echo \"<secret ephemeral='no'
-            private='no'><uuid>$cinder_rbd_secret_uuid</uuid><usage
-            type='ceph'><name>client.cinder_volume</name></usage></secret>\" | \
-            virsh secret-define --file /dev/stdin",
-    unless => "virsh secret-list | egrep $cinder_rbd_secret_uuid",
-  }
-
-  exec { "secret_set_value_cinder_volume":
-    command => "virsh secret-set-value --secret $cinder_rbd_secret_uuid \
-                --base64 $(ceph --name mon. --key ${ceph_mon_key} auth get-key \
-                client.cinder_volume)",
-    unless => "virsh -q secret-get-value $cinder_rbd_secret_uuid | \
-             grep \"$(grep ceph --name mon. --key ${ceph_mon_key} auth get-key \
-                        client.cinder_volume)\"",
-    require => Exec["secret_define_cinder_volume"],
-    notify => Service ['libvirt'],
+    command => 'virsh net-destroy default && virsh net-undefine default',
+    path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
+    onlyif  => 'virsh -q net-list | grep -q default' ,
   }
 
   rjil::jiocloud::consul::service {'nova-compute':
@@ -136,15 +83,15 @@ class rjil::nova::compute (
   ensure_resource(package, 'ethtool')
 
   Package <| name == 'ethtool' |> ->
-  file { "/etc/init/disable-gro.conf":
+  file { '/etc/init/disable-gro.conf':
     source => 'puppet:///modules/rjil/disable-gro.conf',
     owner  => 'root',
     group  => 'root',
     mode   => '0644'
   } ~>
-  exec { "disable-gro":
+  exec { 'disable-gro':
     command     => 'true ; cd /sys/class/net ; for x in *; do ethtool -K $x gro off || true; done',
-    path        => "/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin",
+    path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
     refreshonly => true
   }
 }

--- a/manifests/nova/compute/rbd.pp
+++ b/manifests/nova/compute/rbd.pp
@@ -1,0 +1,91 @@
+##
+# Class: rjil::nova::compute::rbd
+#
+# Setup ceph configurations for nova compute.
+#
+
+class rjil::nova::compute::rbd (
+  $ceph_mon_key,
+  $cinder_rbd_secret_uuid,
+  $ceph_keyring_file_owner    = 'nova',
+  $ceph_keyring_path          = '/etc/ceph/keyring.ceph.client.cinder_volume',
+  $ceph_keyring_cap           = 'mon "allow r" osd "allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rx pool=images"',
+  $rbd_user                   = 'cinder_volume',
+) {
+
+  ##
+  # service blocker to stmon before mon_config to be run.
+  # Mon_config must be run on all ceph client nodes also.
+  # Also mon_config should be setup before cinder_volume to be started,
+  #   as ceph configuration is required cinder_volume to function.
+  ##
+
+  ensure_resource('rjil::service_blocker', 'stmon', {})
+  Rjil::Service_blocker['stmon']  ->
+  Class['rjil::ceph::mon_config'] ->
+  Ceph::Conf::Clients['cinder_volume'] ->
+  Exec['secret_set_value_cinder_volume']
+
+  ##
+  # This will fix the failure on puppet first run.
+  ##
+  Ceph::Conf::Mon_config<||> ->
+  Exec['secret_set_value_cinder_volume']
+
+  Class['::nova'] ->
+  Ceph::Auth['cinder_volume']
+
+  Package['libvirt'] ->
+  Exec['secret_define_cinder_volume']
+
+  include ::ceph::conf
+  include rjil::ceph::mon_config
+  include ::nova
+  include ::nova::compute
+  include ::nova::compute::libvirt
+
+  ##
+  # Add ceph keyring for cinder_volume. This is required cinder to connect to
+  # ceph.
+  ##
+
+  ::ceph::auth {'cinder_volume':
+    mon_key      => $ceph_mon_key,
+    client       => $rbd_user,
+    file_owner   => $ceph_keyring_file_owner,
+    keyring_path => $ceph_keyring_path,
+    cap          => $ceph_keyring_cap,
+  }
+
+  ##
+  # Add ceph configuration for cinder_volume. This is required to find keyring
+  # path while connecting to ceph as cinder_volume.
+  ##
+  ::ceph::conf::clients {'cinder_volume':
+    keyring => $ceph_keyring_path,
+  }
+
+
+  ##
+  # setup virsh secrets for ceph auth
+  ##
+  exec { "secret_define_cinder_volume":
+    command => "echo \"<secret ephemeral='no'
+            private='no'><uuid>$cinder_rbd_secret_uuid</uuid><usage
+            type='ceph'><name>client.cinder_volume</name></usage></secret>\" | \
+            virsh secret-define --file /dev/stdin",
+    unless => "virsh secret-list | egrep $cinder_rbd_secret_uuid",
+  }
+
+  exec { "secret_set_value_cinder_volume":
+    command => "virsh secret-set-value --secret $cinder_rbd_secret_uuid \
+                --base64 $(ceph --name mon. --key ${ceph_mon_key} auth get-key \
+                client.cinder_volume)",
+    unless => "virsh -q secret-get-value $cinder_rbd_secret_uuid | \
+             grep \"$(grep ceph --name mon. --key ${ceph_mon_key} auth get-key \
+                        client.cinder_volume)\"",
+    require => Exec["secret_define_cinder_volume"],
+    notify => Service ['libvirt'],
+  }
+
+}

--- a/manifests/nova/compute/rbd.pp
+++ b/manifests/nova/compute/rbd.pp
@@ -14,6 +14,13 @@ class rjil::nova::compute::rbd (
 ) {
 
   ##
+  # Test rbd key is installed to libvirt.
+  ##
+  class {'rjil::test::compute::rbd':
+    cinder_rbd_secret_uuid => $cinder_rbd_secret_uuid,
+  }
+
+  ##
   # service blocker to stmon before mon_config to be run.
   # Mon_config must be run on all ceph client nodes also.
   # Also mon_config should be setup before cinder_volume to be started,

--- a/manifests/test/compute.pp
+++ b/manifests/test/compute.pp
@@ -7,11 +7,4 @@ class rjil::test::compute {
   $scripts = ['nova-compute.sh']
 
   rjil::test { $scripts: }
-
-  file { "/usr/lib/jiocloud/tests/cinder-secret.sh":
-    content => template('rjil/tests/cinder-secret.sh.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-  }
 }

--- a/manifests/test/compute/rbd.pp
+++ b/manifests/test/compute/rbd.pp
@@ -1,0 +1,15 @@
+#
+# Class: rjil::test::compute::rbd
+#
+
+class rjil::test::compute::rbd (
+  $cinder_rbd_secret_uuid,
+) {
+
+  file { "/usr/lib/jiocloud/tests/cinder-secret.sh":
+    content => template('rjil/tests/cinder-secret.sh.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+  }
+}

--- a/spec/classes/nova/compute_rbd_spec.rb
+++ b/spec/classes/nova/compute_rbd_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'hiera-puppet-helper'
+
+describe 'rjil::nova::compute::rbd' do
+
+  let :facts do
+    {
+      :operatingsystem  => 'Debian',
+      :osfamily         => 'Debian',
+      :concat_basedir   => '/tmp',
+      :hostname         => 'node1',
+      :ipaddress_vhost0 => '10.1.1.1',
+    }
+  end
+
+  let :params do
+    {
+      'ceph_mon_key' => 'secret',
+      'cinder_rbd_secret_uuid' => 'secret2'
+    }
+  end
+
+  let :hiera_data do
+    {
+      'rjil::ceph::mon_config::mon_config'             => 'foo',
+      'nova::network::neutron::neutron_admin_password' => 'pw',
+      'ceph::conf::fsid'                               => 'fsid',
+    }
+  end
+
+  it 'should deploy defaults' do
+    should contain_rjil__service_blocker('stmon') \
+      .that_comes_before('Class[rjil::ceph::mon_config]') 
+
+    [
+      'ceph::conf',
+      'rjil::ceph::mon_config',
+      'nova',
+      'nova::compute',
+      'nova::compute::libvirt'
+    ].each do |x|
+      should contain_class(x)
+    end
+
+    should contain_ceph__auth('cinder_volume')
+
+    should contain_ceph__conf__clients('cinder_volume')
+
+    should contain_exec('secret_define_cinder_volume').with({
+      :command => "echo \"<secret ephemeral='no'
+            private='no'><uuid>secret2</uuid><usage
+            type='ceph'><name>client.cinder_volume</name></usage></secret>\" | \
+            virsh secret-define --file /dev/stdin",
+      :unless => "virsh secret-list | egrep secret2"
+    })
+
+
+  end
+
+end

--- a/spec/classes/nova/compute_spec.rb
+++ b/spec/classes/nova/compute_spec.rb
@@ -32,14 +32,14 @@ describe 'rjil::nova::compute' do
         'rjil::nova::zmq_config',
         'nova::client',
         'nova',
+        'nova::compute',
         'nova::compute::neutron',
+        'nova::compute::libvirt',
         'rjil::nova::compute::rbd',
         'rjil::nova::logrotate::manage'
       ].each do |x|
         should contain_class(x)
       end
-
-      should contain_class('nova::compute')
 
       should contain_rjil__jiocloud__logrotate('nova-compute') \
         .with_logdir('/var/log/nova/')
@@ -80,25 +80,30 @@ describe 'rjil::nova::compute' do
           :refreshonly => true
         }
       )
+
+      should contain_package('libvirt').that_comes_before('Exec[rm_virbr0]')
+
     end
   end
 
-  context 'with ironic and no rbd' do
+  context 'with ironic' do
 
     let :params do
       {
-        :rbd_enabled    => false,
         :compute_driver => 'ironic',
       }
     end
 
-    it 'should deploy with ironic and without rbd' do
+    it 'should deploy with ironic' do
 
       should contain_class('nova::compute::ironic')
 
       should_not contain_class('nova::compute::neutron')
 
       should_not contain_class('rjil::nova::compute::rbd')
+
+      should_not contain_package('libvirt')
+
     end
   end
 

--- a/spec/classes/nova/compute_spec.rb
+++ b/spec/classes/nova/compute_spec.rb
@@ -9,61 +9,97 @@ describe 'rjil::nova::compute' do
       :osfamily         => 'Debian',
       :concat_basedir   => '/tmp',
       :hostname         => 'node1',
-      :ipaddress_vhost0 => '10.1.1.1',
-    }
-  end
-
-  let :params do
-    {
-      'ceph_mon_key' => 'secret',
-      'cinder_rbd_secret_uuid' => 'secret2'
+      :ipaddress        => '10.1.0.10',
     }
   end
 
   let :hiera_data do
     {
-      'rjil::ceph::mon_config::mon_config'             => 'foo',
-      'nova::network::neutron::neutron_admin_password' => 'pw',
-      'ceph::conf::fsid'                               => 'fsid',
-      'private_interface'                              => 'eth0',
+      'rjil::ceph::mon_config::mon_config'               => 'foo',
+      'nova::network::neutron::neutron_admin_password'   => 'pw',
+      'ceph::conf::fsid'                                 => 'fsid',
+      'rjil::nova::compute::rbd::ceph_mon_key'           => 'key',
+      'rjil::nova::compute::rbd::cinder_rbd_secret_uuid' => '6d6502c1-1148-4994-8b85-0f1436b5d3f6',
+      'nova::compute::ironic::keystone_password'         => 'secret'
     }
   end
 
-  it 'should deploy defaults' do
-    should contain_file('/usr/lib/jiocloud/tests/nova-compute.sh').with({
-      'source' => 'puppet:///modules/rjil/tests/nova-compute.sh',
-    })
-    should contain_package('python-six').with_ensure('latest')
-    should contain_rjil__service_blocker('stmon')
-    [
-      'rjil::ceph::mon_config',
-      'rjil::nova::zmq_config',
-      'nova::client',
-      'nova',
-      'nova::compute::libvirt',
-      'nova::compute::neutron',
-      'nova::network::neutron'
-    ].each do |x|
-      should contain_class(x)
+  context 'with defaults' do
+
+    it 'it should deploy libvirt with rbd config' do
+      [
+        'rjil::test::compute',
+        'rjil::nova::zmq_config',
+        'nova::client',
+        'nova',
+        'nova::compute::neutron',
+        'rjil::nova::compute::rbd',
+        'rjil::nova::logrotate::manage'
+      ].each do |x|
+        should contain_class(x)
+      end
+
+      should contain_class('nova::compute')
+
+      should contain_rjil__jiocloud__logrotate('nova-compute') \
+        .with_logdir('/var/log/nova/')
+
+      should contain_exec('rm_virbr0').with(
+        {
+          :command => 'virsh net-destroy default && virsh net-undefine default',
+          :path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
+          :onlyif  => 'virsh -q net-list | grep -q default' 
+        }
+      )
+
+      should contain_package('python-six').with_ensure('latest')
+
+      should contain_package('ethtool')
+
+      should contain_rjil__jiocloud__consul__service('nova-compute').with(
+        {
+          :port          => 0,               
+          :check_command => "sudo nova-manage service list | grep 'nova-compute.*node1.*enabled.*:-)'",
+          :interval      => '120s',
+        }
+      )
+
+      should contain_file('/etc/init/disable-gro.conf').with(
+        {
+          :source => 'puppet:///modules/rjil/disable-gro.conf',
+          :owner  => 'root',  
+          :group  => 'root',  
+          :mode   => '0644'
+        }
+      )
+
+      should contain_exec('disable-gro').with(
+        {
+          :command     => 'true ; cd /sys/class/net ; for x in *; do ethtool -K $x gro off || true; done',
+          :path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
+          :refreshonly => true
+        }
+      )
+    end
+  end
+
+  context 'with ironic and no rbd' do
+
+    let :params do
+      {
+        :rbd_enabled    => false,
+        :compute_driver => 'ironic',
+      }
     end
 
-    should contain_class('nova::compute').with({
-      'vncserver_proxyclient_address' => '10.1.1.1'
-    })
+    it 'should deploy with ironic and without rbd' do
 
-    should contain_ceph__auth('cinder_volume')
+      should contain_class('nova::compute::ironic')
 
-    should contain_ceph__conf__clients('cinder_volume')
+      should_not contain_class('nova::compute::neutron')
 
-    should contain_exec('rm_virbr0').with({
-      'command' => "virsh net-destroy default && virsh net-undefine default",
-      'onlyif'  => "virsh -q net-list | grep -q default",
-    })
-
-    ['nova-compute', 'nova-manage'].each do |x|
-      should contain_rjil__jiocloud__logrotate(x).with_logdir('/var/log/nova/')
+      should_not contain_class('rjil::nova::compute::rbd')
     end
-
   end
 
 end

--- a/spec/classes/test/compute_rbd_spec.rb
+++ b/spec/classes/test/compute_rbd_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'rjil::test::compute::rbd' do
+  context "with defaults" do
+    let :params do
+      {
+        :cinder_rbd_secret_uuid => 'secret'
+      }
+    end
+    it do
+      should contain_file('/usr/lib/jiocloud/tests/cinder-secret.sh') \
+        .with_content(/virsh -q secret-get-value/)
+        .with_owner('root') \
+        .with_group('root') \
+        .with_mode('0755')
+    end
+  end
+end

--- a/spec/classes/test/compute_spec.rb
+++ b/spec/classes/test/compute_spec.rb
@@ -5,13 +5,5 @@ describe 'rjil::test::compute' do
     it do
       should contain_rjil__test('nova-compute.sh')
     end
-    
-    it do
-      should contain_file('/usr/lib/jiocloud/tests/cinder-secret.sh') \
-        .with_content(/virsh -q secret-get-value/)
-        .with_owner('root') \
-        .with_group('root') \
-        .with_mode('0755')
-    end
   end
 end


### PR DESCRIPTION
moved ceph rbd specific code to rjil::nova::compute::rbd, so that
rjil::nova::compute can be called without having rbd backend/configuration, such
as for ironic.