### PR TITLE
Reduced footprint for the builds

### DIFF
--- a/environment/jio.map.yaml
+++ b/environment/jio.map.yaml
@@ -2,9 +2,9 @@ image:
   trusty: 5d246189-a666-470c-8cee-36ee489cbd9e
 flavor:
   small: da9ba7b5-be67-4a62-bb35-a362e05ba2f2
-  medium: 8b1b17e5-55a9-46b7-90c3-57e1c1696223
-  large: 342a1fc6-0f15-41dc-966a-70f449f582fb
-  storage: 342a1fc6-0f15-41dc-966a-70f449f582fb
+  medium: da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+  large: da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+  storage: da9ba7b5-be67-4a62-bb35-a362e05ba2f2
 networks:
    default:
      - 7270b05c-0086-44d3-994f-4099ef6fc4bf


### PR DESCRIPTION
We have the flavors with good amount of resources, so we do not need to use
large flavors for our builds, so changing as below
medium to small
large to mmedium
storage to medium