### PR TITLE
UC|Create common code for network interface configuration

### DIFF
--- a/files/etc_network_interfaces
+++ b/files/etc_network_interfaces
@@ -1,0 +1,11 @@
+##
+# THIS FILE IS MANAGED BY PUPPET
+##
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+source /etc/network/interfaces.d/*.cfg

--- a/manifests/netconfig.pp
+++ b/manifests/netconfig.pp
@@ -1,0 +1,25 @@
+#
+# class rjil::netconfig
+#   Configure /etc/network/interfaces to source extra interface configurations
+#   from /etc/network/interfaces.d, and loopback interface configuration.
+#   It also create execs network_down and network_up which would be called from
+#   rjil::network::interface
+#
+
+class rjil::netconfig {
+
+  file {'/etc/network/interfaces':
+    ensure => file,
+    source => 'puppet:///modules/rjil/etc_network_interfaces',
+  }
+
+  exec { 'network_down':
+    command     => '/sbin/ifdown -a',
+    refreshonly => true,
+  }
+
+  exec { 'network_up':
+    command     => '/sbin/ifup -a',
+    refreshonly => true,
+  }
+}

--- a/manifests/netconfig/interface.pp
+++ b/manifests/netconfig/interface.pp
@@ -1,0 +1,97 @@
+#
+# Define - rjil::netconfig::interface
+#   Configure network interfaces
+#
+# == parameters
+#
+# [*interface*]
+#   interface name
+#
+# [*onboot*]
+#   whether to enable on boot or not
+#
+# [*method*]
+#   Methods - static, dhcp, manual
+#
+# [*macaddress*]
+#   Mac address
+#
+# [*ipaddress*]
+#   IP Address
+#
+# [*netmask*]
+#   Subnet mask
+#
+# [*network*]
+#   Network
+#
+# [*gateway*]
+#   Gateway
+#
+# [*nameservers*]
+#   Array of all name servers
+#
+# [*searchdomains*]
+#   An array with all search domains.
+#
+# [*options*]
+#   A hash to configure any extra options like pre-up, up, down, pre-down.
+#   Multiple options for specific state can be specified as an array. e.g
+#   options => {
+#                 up   => ['do this','do this too'],
+#                 down => 'do this only'
+#               }
+#
+# [*refresh_network*]
+# Whether to restart network after the interface file changes or not.
+#
+
+define rjil::netconfig::interface (
+  $interface       = $name,
+  $onboot          = true,
+  $family          = 'inet',
+  $method          = 'dhcp',
+  $macaddress      = undef,
+  $ipaddress       = undef,
+  $netmask         = undef,
+  $network         = undef,
+  $broadcast       = undef,
+  $gateway         = undef,
+  $nameservers     = [],
+  $searchdomains   = [],
+  $options         = {},
+  $refresh_network = true,
+) {
+
+  include rjil::netconfig
+
+  if ($method == 'static') and (! $ipaddress) {
+    fail('ipaddress is required for static method')
+  }
+
+  if ($method == 'static') and (! $netmask) {
+    fail('netmask is required for static method')
+  }
+
+  if $refresh_network {
+    file {"/etc/network/interfaces.d/${interface}.cfg.staging":
+      ensure  => present,
+      content => template('rjil/etc_network_interfaces_d_file.erb'),
+      notify  => Exec['network_down']
+    }
+
+    file {"/etc/network/interfaces.d/${interface}.cfg":
+      ensure  => file,
+      source  => "/etc/network/interfaces.d/${interface}.cfg.staging",
+      require => Exec['network_down'],
+      notify  => Exec['network_up'],
+    }
+
+  } else {
+    file {"/etc/network/interfaces.d/${interface}.cfg":
+      ensure  => file,
+      content => template('rjil/etc_network_interfaces_d_file.erb'),
+    }
+  }
+
+}

--- a/spec/classes/netconfig_spec.rb
+++ b/spec/classes/netconfig_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'rjil::netconfig' do
+  it 'should create basic network config' do
+
+    should contain_file('/etc/network/interfaces').with_source('puppet:///modules/rjil/etc_network_interfaces')
+
+    should contain_exec('network_down').with(
+      {
+        :command     => '/sbin/ifdown -a',
+        :refreshonly => true,
+      }
+    )
+
+    should contain_exec('network_up').with(
+      {
+        :command     => '/sbin/ifup -a',
+        :refreshonly => true,
+      }
+    )
+  end
+end

--- a/spec/defines/netconfig_interface_spec.rb
+++ b/spec/defines/netconfig_interface_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe 'rjil::netconfig::interface' do
+
+  let(:title){ 'test_interface' }
+
+  context 'with defaults' do
+    let :params do
+      {
+        :interface => 'eth0',
+      }
+    end
+
+    it 'should configure interface with dhcp' do
+
+      should contain_class('rjil::netconfig')
+
+      should contain_file('/etc/network/interfaces.d/eth0.cfg.staging').with_content( <<-EOF.gsub(/^ {8}/, '')
+        ##
+        # MANAGED BY PUPPET
+        #
+        # Interface eth0
+        auto eth0
+        iface eth0 inet dhcp
+        EOF
+      ).that_notifies('Exec[network_down]')
+
+      should contain_file('/etc/network/interfaces.d/eth0.cfg').with(
+        {
+          :ensure  => 'file',
+          :source  => '/etc/network/interfaces.d/eth0.cfg.staging',
+          :require => 'Exec[network_down]',
+          :notify  => 'Exec[network_up]',
+        }
+      )
+    end
+  end
+
+  context 'static without ip address' do
+    let :params do
+      {
+        :interface => 'eth0',
+        :method    => 'static',
+      }
+    end
+
+    it 'should fail' do
+      expect {
+        should compile
+      }.to raise_error(Puppet::Error, /ipaddress is required for static method/)
+    end
+
+  end
+
+  context 'static without netmask' do
+
+    let :params do
+    {
+      :interface => 'eth0',
+      :method    => 'static',
+      :ipaddress => '10.1.1.1',
+    }
+    end
+
+    it 'should fail' do
+      expect {
+        should compile
+      }.to raise_error(Puppet::Error, /netmask is required for static method/)
+    end
+
+  end
+
+  context 'static ' do
+
+    let :params do
+      {
+        :interface => 'eth0',
+        :method    => 'static',
+        :ipaddress => '10.1.1.1',
+        :netmask   => '255.255.255.0',
+        :options   => {
+                        'up'   => ['do this','do this too'],
+                        'down' => 'do this one'
+                      }
+      }
+    end
+
+    it 'should setup static interface file' do
+      should contain_file('/etc/network/interfaces.d/eth0.cfg.staging') \
+        .with_content(/address 10.1.1.1/)
+        .with_content(/netmask 255.255.255.0/)
+        .with_content(/up do this/)
+        .with_content(/up do this too/)
+        .with_content(/down do this one/)
+
+      should_not contain_file('/etc/network/interfaces.d/eth0.cfg.staging') \
+        .with_content(/hwaddress ether/)
+
+      should_not contain_file('/etc/network/interfaces.d/eth0.cfg.staging') \
+        .with_content(/dns-nameservers/)
+
+      should_not contain_file('/etc/network/interfaces.d/eth0.cfg.staging') \
+        .with_content(/dns-search/)
+
+      should_not contain_file('/etc/network/interfaces.d/eth0.cfg.staging') \
+        .with_content(/gateway/)
+
+      should_not contain_file('/etc/network/interfaces.d/eth0.cfg.staging') \
+        .with_content(/network/)
+
+    end
+  end
+end

--- a/templates/etc_network_interfaces_d_file.erb
+++ b/templates/etc_network_interfaces_d_file.erb
@@ -1,0 +1,39 @@
+##
+# MANAGED BY PUPPET
+#
+# Interface <%= @interface %>
+<% if @onboot -%>
+auto <%= @interface %>
+<% end -%>
+iface <%= @interface %> <%= @family %> <%= @method %>
+<% if @macaddress -%>
+    hwaddress ether <%= @macaddress %>
+<% end -%>
+<% if @method == 'static' -%>
+    address <%= @ipaddress %>
+    netmask <%= @netmask %>
+  <% if @network -%>
+    network <%= @network %>
+  <% end -%>
+  <% if @broadcast -%>
+    broadcast <%= @broadcast %>
+  <% end -%>
+  <% if @gateway -%>
+    gateway <%= @gateway %>
+  <% end -%>
+  <% if ! @nameservers.empty? -%>
+    dns-nameservers <%= @nameservers.join(' ') %>
+  <% end -%>
+  <% if ! @searchdomains.empty? -%>
+    dns-search <%= @searchdomains.join(' ') %>
+  <% end -%>
+<% end -%>
+<% @options.each do |key, val| -%>
+  <% if val.is_a?(Array) -%>
+    <% val.each do |x| -%>
+    <%= key %> <%= x %>
+    <% end -%>
+  <% else -%>
+    <%= key %> <%= val %>
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
Network interface configuration code need to be reused. I checked if we could
use the module puppet-network, but it dont have the configuration which we need.
Another reason is that we would need to refresh the network before writing the
configuration, which is not handled in the existing code in the module.

Added spec tests also