### PR TITLE
ceph: improve gate builds by reducing warn states

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -64,8 +64,8 @@ fixtures:
       repo: https://github.com/puppetlabs/puppetlabs-apache
       ref: 1.2.0
     ceph:
-      repo: https://github.com/jiocloud/puppet-ceph
-      ref: 'origin/svn_to_git_2'
+      repo: https://github.com/theanalyst/puppet-ceph
+      ref: f/object-skew
     apt:
       repo: https://github.com/puppetlabs/puppetlabs-apt
       ref: 1.8.0

--- a/hiera/data/env/at.yaml
+++ b/hiera/data/env/at.yaml
@@ -19,6 +19,7 @@ tempest::admin_username: tempest_admin
 
 ceph::conf::pool_default_pg_num: 128
 ceph::conf::pool_default_pgp_num: 128
+ceph::conf::mon_pg_warn_max_object_skew: 30
 
 rjil::neutron::contrail::fip_pools:
   public:


### PR DESCRIPTION
Since rgw comes up and there is a consul test to create swift buckets
and delete, buckets index pool gets skewed a bit and ceph health goes
into a warn state, which increases the amount of puppet runs to bring
the state to heatlhy. Overriding this ratio for gate builds.

Reported-by: Anshu Prateek <anshu.prateek@ril.com>
Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>