### PR TITLE
fix vgw

### DIFF
--- a/hiera/data/env/at.yaml
+++ b/hiera/data/env/at.yaml
@@ -35,3 +35,5 @@ rjil::neutron::contrail::fip_pools:
     rt_number: 10001
     public: false
     tenants: ['tempest','mgmt_tenant','internal_tenant']
+
+contrail::vrouter::vgw_subnets: ['100.1.0.0/24']

--- a/hiera/data/env/gate.yaml
+++ b/hiera/data/env/gate.yaml
@@ -31,3 +31,5 @@ rjil::neutron::contrail::fip_pools:
     cidr: 99.0.0.0/24
     public: false
     tenants: ['tempest','testtenant']
+
+contrail::vrouter::vgw_subnets: ['100.1.0.0/24']

--- a/hiera/data/role/gcp.yaml
+++ b/hiera/data/role/gcp.yaml
@@ -3,11 +3,6 @@
 # without any physical router, in test and development environments.
 ##
 contrail::vrouter::vgw_enabled: true
-contrail::vrouter::vgw_subnets: "%{hiera('rjil::neutron::contrail::public_cidr')}"
 contrail::vrouter::dest_net: 0.0.0.0/0
 contrail::vrouter::vrf: 'default-domain:services:public:public'
-##
-# disabling validation checks for vgw as vgw is not working there. This will be
-# enabled once this is fixed.
-##
-#rjil::test::contrail_vrouter::vgw_enabled: "%{hiera('contrail::vrouter::vgw_enabled')}"
+rjil::test::contrail_vrouter::vgw_enabled: "%{hiera('contrail::vrouter::vgw_enabled')}"


### PR DESCRIPTION
VGW was not coming up because of missing ip_block configuration. This was
happend because of a hiera reference added for that param, which was changed
once, but missed to change the reference.