### PR TITLE
Explicitely disable access to /run/shm/lttng* for vms

### DIFF
--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -97,4 +97,15 @@ class rjil::nova::compute (
     path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
     refreshonly => true
   }
+
+  ##
+  # Specifically deny read access to /run/shm/lttng for vms. This will remove
+  # the apparmor warnings on compute nodes.
+  ##
+  file_line {'apparmor_deny_read_lttng':
+    path    => '/etc/apparmor.d/abstractions/libvirt-qemu',
+    line    => '  deny /run/shm/lttng* r,',
+    require => Package['libvirt'],
+    notify  => Service['apparmor'],
+  }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -15,6 +15,7 @@ class rjil::system(
 
   include ::timezone
 
+  include rjil::system::apparmor
   include rjil::system::apt
   include rjil::system::accounts
   include rjil::system::metrics

--- a/manifests/system/apparmor.pp
+++ b/manifests/system/apparmor.pp
@@ -1,0 +1,13 @@
+##
+# This class provide code for apparmor management
+##
+class rjil::system::apparmor {
+
+  package { 'apparmor':
+    ensure => present,
+  }
+
+  service { 'apparmor':
+    ensure => running,
+  }
+}

--- a/spec/classes/nova/compute_spec.rb
+++ b/spec/classes/nova/compute_spec.rb
@@ -83,6 +83,15 @@ describe 'rjil::nova::compute' do
 
       should contain_package('libvirt').that_comes_before('Exec[rm_virbr0]')
 
+      should contain_file_line('apparmor_deny_read_lttng').with(
+        {
+          :path    => '/etc/apparmor.d/abstractions/libvirt-qemu',
+          :line    => '  deny /run/shm/lttng* r,',
+          :require => 'Package[libvirt]',
+          :notify  => 'Service[apparmor]',
+        }
+      )
+
     end
   end
 

--- a/spec/classes/system/apparmor_spec.rb
+++ b/spec/classes/system/apparmor_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'rjil::system::apparmor' do
+  let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian'}}
+
+  it 'should install and start apparmor' do
+    should contain_package('apparmor').with_ensure('present')
+    should contain_service('apparmor').with_ensure('running')
+  end
+end

--- a/spec/classes/system_spec.rb
+++ b/spec/classes/system_spec.rb
@@ -40,6 +40,7 @@ describe 'rjil::system' do
       should contain_class('rjil::system::ntp')
       should contain_class('rjil::system::apt')
       should contain_class('rjil::system::accounts')
+      should contain_class('rjil::system::apparmor')
       should contain_package('molly-guard')
 
       should contain_file_line('domain_search') \


### PR DESCRIPTION
vm is trying to access /run/shm/lttng* file which is denied by apparmor, and
thus apparmor was throwing the denied logs in high volume. Explicitely denying
this should stop logging the incident.

Also this patch add apparmor package and service management code