### PR TITLE
UC | Make flavor management optional

### DIFF
--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -35,13 +35,11 @@ class rjil::nova::controller (
   $max_local_block_devices = 3,
   $rewrites                = undef,
   $headers                 = undef,
+  $manage_flavors          = true,
 ) {
 
 # Tests
   include rjil::test::nova_controller
-  class { 'rjil::test::nova_flavor':
-    flavors => $flavors,
-  }
 
   nova_config {
     'DEFAULT/default_floating_pool':      value => $default_floating_pool;
@@ -162,17 +160,23 @@ class rjil::nova::controller (
   include ::nova::vncproxy
   include ::nova::quota
 
-  ##
-  # Create flavors
-  ##
-  Service['httpd'] -> Nova_flavor<||>
-  create_resources('nova_flavor', $flavors, {auth => $nova_auth})
+  if $manage_flavors {
+    ##
+    # Create flavors
+    ##
+    Service['httpd'] -> Nova_flavor<||>
+    create_resources('nova_flavor', $flavors, {auth => $nova_auth})
 
-  ##
-  # Purge unmanaged flavors
-  ##
-  resources {'nova_flavor':
-    purge => true,
+    class { 'rjil::test::nova_flavor':
+      flavors => $flavors,
+    }
+
+    ##
+    # Purge unmanaged flavors
+    ##
+    resources {'nova_flavor':
+      purge => true,
+    }
   }
 
   ##

--- a/spec/classes/nova/controller_spec.rb
+++ b/spec/classes/nova/controller_spec.rb
@@ -37,6 +37,20 @@ describe 'rjil::nova::controller' do
     }
   end
 
+  context 'without manage_flavors' do
+    let :params do
+      {
+        :manage_flavors => false,
+      }
+    end
+
+    it 'should not manage flavors' do
+      should_not contain_nova_flavor
+
+      should_not contain_rjil__test__nova_flavor
+    end
+  end
+
   context 'with http, defaults' do
     it  do
       should contain_class('rjil::apache')


### PR DESCRIPTION
Sometimes you may not need to manage nova flavors, so making it optional. This
is useful in case of undercloud controller where the flavors would have
extra_specs which are not supported by nova_flavor at this moment (we currently
use openstack client in nova_flavor which doesnt support setting extra_specs).