### PR TITLE
UC|Configure neutron only if ask to do so in tempest provision

### DIFF
--- a/hiera/data/role/uc.yaml
+++ b/hiera/data/role/uc.yaml
@@ -7,3 +7,6 @@ apache::default_vhost: false
 rjil::glance::backend: file
 
 nova::api::neutron_metadata_proxy_shared_secret: false
+
+# neutron is already configured in case of uc, so no need to configure it again.
+rjil::tempest::provision::configure_neutron: false

--- a/manifests/tempest/provision.pp
+++ b/manifests/tempest/provision.pp
@@ -8,37 +8,40 @@ class rjil::tempest::provision (
   $service_tenant         = 'services',
   $neutron_admin_user     = 'neutron',
   $neutron_admin_password = 'neutron',
+  $configure_neutron      = true,
 ) {
 
 ##
 # Create required resources in order to run tempest
 ##
 
-  ##
-  # Neutron_network and neutron_subnet need neutron.conf with keystone
-  # configuration added. So adding appropriate entries.
-  ##
+  if $configure_neutron {
+    ##
+    # Neutron_network and neutron_subnet need neutron.conf with keystone
+    # configuration added. So adding appropriate entries.
+    ##
 
-  file {'/etc/neutron':
-    ensure => directory,
-  }
+    file {'/etc/neutron':
+      ensure => directory,
+    }
 
-  file {'/etc/neutron/neutron.conf':
-    ensure  => file,
-    require => File['/etc/neutron'],
-  }
+    file {'/etc/neutron/neutron.conf':
+      ensure  => file,
+      require => File['/etc/neutron'],
+    }
 
-  File['/etc/neutron/neutron.conf'] -> Neutron_config<||>
-  Neutron_config<||> -> Neutron_network<||>
-  Neutron_config<||> -> Neutron_subnet<||>
+    File['/etc/neutron/neutron.conf'] -> Neutron_config<||>
+    Neutron_config<||> -> Neutron_network<||>
+    Neutron_config<||> -> Neutron_subnet<||>
 
-  neutron_config {
-    'keystone_authtoken/auth_host':         value => $auth_host;
-    'keystone_authtoken/auth_port':         value => $auth_port;
-    'keystone_authtoken/auth_protocol':     value => $auth_protocol;
-    'keystone_authtoken/admin_tenant_name': value => $service_tenant;
-    'keystone_authtoken/admin_user':        value => $neutron_admin_user;
-    'keystone_authtoken/admin_password':    value => $neutron_admin_password;
+    neutron_config {
+      'keystone_authtoken/auth_host':         value => $auth_host;
+      'keystone_authtoken/auth_port':         value => $auth_port;
+      'keystone_authtoken/auth_protocol':     value => $auth_protocol;
+      'keystone_authtoken/admin_tenant_name': value => $service_tenant;
+      'keystone_authtoken/admin_user':        value => $neutron_admin_user;
+      'keystone_authtoken/admin_password':    value => $neutron_admin_password;
+    }
   }
 
   include ::tempest::provision

--- a/spec/classes/tempest_provision_spec.rb
+++ b/spec/classes/tempest_provision_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'rjil::tempest::provision' do
+
+  let :facts do
+    {
+      :operatingsystem => 'Ubuntu',
+      :osfamily        => 'Debian',
+      :lsbdistid       => 'ubuntu',
+    }
+  end
+
+  context 'with defaults' do
+    it do
+      should contain_file('/etc/neutron').with_ensure('directory')
+
+      should contain_file('/etc/neutron/neutron.conf') \
+        .with_ensure('file') \
+        .that_requires('File[/etc/neutron]')
+
+      {
+        'keystone_authtoken/auth_host'         => 'identity.jiocloud.com',
+        'keystone_authtoken/auth_port'         => 5000,
+        'keystone_authtoken/auth_protocol'     => 'https',
+        'keystone_authtoken/admin_tenant_name' => 'services',
+        'keystone_authtoken/admin_user'        => 'neutron',
+        'keystone_authtoken/admin_password'    => 'neutron'
+      }.each do | k, v|
+        should contain_neutron_config(k).with_value(v)
+      end
+      
+      should contain_class('tempest::provision')
+    end
+  end
+
+  context 'with configure_neutron false' do
+    let :params do
+      {
+        :configure_neutron => false,
+      }
+    end
+
+    it do
+      should_not contain_file('/etc/neutron')
+
+      should_not contain_file('/etc/neutron/neutron.conf')
+
+      should_not contain_neutron_config
+    end
+  end  
+
+end


### PR DESCRIPTION
In case of undercloud neutron is already present in the same machine and thus
reconfiguring neutron resources cause duplicate resource errors, and thus making
the configuration optional, with default to be on. Also adding an override in uc
role.