### PR TITLE
UC | Support overcast based deployments

### DIFF
--- a/build_scripts/common.sh
+++ b/build_scripts/common.sh
@@ -28,14 +28,24 @@ if [ -n "${xtrace_was_on}" ]; then
   set -x
 fi
 
+##
 # Load map from generic image, flavor and network names to
 # cloud specific ids
+#
+# overcast use ini file for mapping.
+##
+if [ $provisioner == 'overcast' ]; then
+  mapping_file="environment/${cloud_provider}.map.ini"
+else
+  mapping_file="environment/${cloud_provider}.map.yaml"
+fi
+
 if [ -n "${mapping}" ]
 then
 	mappings_arg="--mappings=${mapping}"
-elif [ -e "environment/${cloud_provider}.map.yaml" ]
+elif [ -e $mapping_file ]
 then
-	mappings_arg="--mappings=environment/${cloud_provider}.map.yaml"
+	mappings_arg="--mappings=${mapping_file}"
 else
 	mappings_arg=""
 fi
@@ -50,13 +60,24 @@ then
 
     # This speeds the whole process up *a lot*
     pip install pip-accel
-    if [ -n "${python_jiocloud_source_branch}" ]; then
+    if [ -n "${python_jiocloud_source_repo}" ]; then
       if [ -z "${python_jiocloud_source_branch}" ]; then
         python_jiocloud_source_branch='master'
       fi
       pip-accel install -e "${python_jiocloud_source_repo}@${python_jiocloud_source_branch}#egg=jiocloud"
     else
       pip-accel install -e git+https://github.com/JioCloud/python-jiocloud#egg=jiocloud
+    fi
+
+    if [ $provisioner == 'overcast' ]; then
+      if [ -n "${overcast_source_repo}" ]; then
+        if [ -z "${overcast_source_branch}" ]; then
+          overcast_source_branch='master'
+        fi
+        pip-accel install -e "${overcast_source_repo}@${overcast_source_branch}#egg=overcast"
+      else
+        pip-accel install -e git+https://github.com/overcastde/python-overcast#egg=overcast
+      fi
     fi
     deactivate
 fi

--- a/build_scripts/deploy.sh
+++ b/build_scripts/deploy.sh
@@ -14,23 +14,30 @@ then
     consul_discovery_token=$(curl http://consuldiscovery.linux2go.dk/new)
 fi
 
-. $(dirname $0)/make_userdata.sh
+##
+# overcast can run scripts independantly, so no need to run anything else.
+##
+if [ $provisioner == 'overcast' ]; then
+    overcast deploy --cfg ${overcast_yaml:-.overcast.yaml} --cleanup cleanup-${project_tag} --suffix ${project_tag} ${mappings_arg} --key ${ssh_key_file:-${HOME}/.ssh/id_rsa.pub} ${stack:-overcloud}
+else
+    . $(dirname $0)/make_userdata.sh
 
-time python -m jiocloud.apply_resources apply ${EXTRA_APPLY_RESOURCES_OPTS} --key_name=${KEY_NAME:-combo} --project_tag=${project_tag} ${mappings_arg} environment/${layout}.yaml userdata.txt
+    time python -m jiocloud.apply_resources apply ${EXTRA_APPLY_RESOURCES_OPTS} --key_name=${KEY_NAME:-combo} --project_tag=${project_tag} ${mappings_arg} environment/${layout}.yaml userdata.txt
 
-# This is crazy, but it seems to help A LOT
-if [ "$cloud_provider" = 'hp' ]
-then
-    sleep 270
-    nova list | grep test${BUILD_NUMBER} | cut -f2 -d' ' | while read uuid; do nova console-log $uuid | grep Giving.up.on.md && nova reboot $uuid || true; done
+    # This is crazy, but it seems to help A LOT
+    if [ "$cloud_provider" = 'hp' ]
+    then
+        sleep 270
+        nova list | grep test${BUILD_NUMBER} | cut -f2 -d' ' | while read uuid; do nova console-log $uuid | grep Giving.up.on.md && nova reboot $uuid || true; done
+    fi
+
+    time $timeout 1200 bash -c 'while ! bash -c "ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag});ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \${ssh_user:-jenkins}@\${ip} python -m jiocloud.orchestrate ping"; do sleep 5; done'
+
+    ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag})
+
+    time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate trigger_update ${BUILD_NUMBER}; do sleep 5; done"
+
+    time $timeout 4000 bash -c "while ! python -m jiocloud.apply_resources list --project_tag=${project_tag} environment/${layout}.yaml | sed -e 's/_/-/g' | ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate verify_hosts ${BUILD_NUMBER} ; do sleep 5; done"
+    time $timeout 2400 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate check_single_version -v ${BUILD_NUMBER} ; do sleep 5; done"
+    time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate get_failures --hosts; do sleep 5; done"
 fi
-
-time $timeout 1200 bash -c 'while ! bash -c "ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag});ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \${ssh_user:-jenkins}@\${ip} python -m jiocloud.orchestrate ping"; do sleep 5; done'
-
-ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag})
-
-time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate trigger_update ${BUILD_NUMBER}; do sleep 5; done"
-
-time $timeout 4000 bash -c "while ! python -m jiocloud.apply_resources list --project_tag=${project_tag} environment/${layout}.yaml | sed -e 's/_/-/g' | ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate verify_hosts ${BUILD_NUMBER} ; do sleep 5; done"
-time $timeout 2400 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate check_single_version -v ${BUILD_NUMBER} ; do sleep 5; done"
-time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate get_failures --hosts; do sleep 5; done"

--- a/environment/jio.map.ini
+++ b/environment/jio.map.ini
@@ -1,0 +1,8 @@
+[images]
+trusty = 5d246189-a666-470c-8cee-36ee489cbd9e
+
+[flavors]
+small = da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+medium = da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+large = da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+storage = da9ba7b5-be67-4a62-bb35-a362e05ba2f2


### PR DESCRIPTION
This patch is to support overcast based deployments along with current one
(jiocloud.apply_resources). This patch introduce number of environment
variables by which deploy.sh will decide which way to deploy the system.

Here are the environment variables:

provisioner: if this is set to "overcast", overcast will be used for the
  provisioning. Default is current way of provisioning (jiocloud.apply resources)
overcast_yaml: this is the patch to overcast.yaml file where it configure
  different stacks and each steps in each stacks. Default one is the
  .overcast.yaml in current directory.
stack: Name of the stack to be deployed. Default is overcloud

overcast_source_repo: source repo for overcast
overcast_source_branch: source branch for overcast.