### PR TITLE
Add encryption for consul

### DIFF
--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -99,6 +99,8 @@ else
   puppet apply --config_version='echo settings' -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests/site.pp\" }"
 fi
 echo 'consul_discovery_token='${consul_discovery_token} > /etc/facter/facts.d/consul.txt
+# default to first 16 bytes of discovery token
+echo 'consul_gossip_encrypt'=`echo ${consul_discovery_token} | cut -b 1-15 | base64` >> /etc/facter/facts.d/consul.txt
 echo 'current_version='${BUILD_NUMBER} > /etc/facter/facts.d/current_version.txt
 echo 'env='${env} > /etc/facter/facts.d/env.txt
 echo 'cloud_provider='${cloud_provider} > /etc/facter/facts.d/cloud_provider.txt

--- a/hiera/data/env/at.yaml
+++ b/hiera/data/env/at.yaml
@@ -1,5 +1,7 @@
 rustedhalo_apt_repo_release: 'trusty-testing'
 
+rjil::jiocloud::consul::encrypt: "%{consul_gossip_encrypt}"
+
 rjil::ceph::osd::autogenerate: true
 rjil::ceph::osd::autodisk_size: 10
 rjil::ceph::osd::osd_journal_size: 2

--- a/manifests/jiocloud/consul.pp
+++ b/manifests/jiocloud/consul.pp
@@ -1,6 +1,9 @@
 # Class: rjil::jiocloud::consul
 #
-class rjil::jiocloud::consul($config_hash) {
+class rjil::jiocloud::consul(
+  $config_hash,
+  $encrypt = false,
+) {
   include dnsmasq
 
   dnsmasq::conf { 'consul':
@@ -8,12 +11,20 @@ class rjil::jiocloud::consul($config_hash) {
     content => 'server=/consul/127.0.0.1#8600',
   }
 
+  if $encrypt {
+    $encrypt_hash = {'encrypt' => $encrypt}
+  } else {
+    $encrypt_hash = {}
+  }
+
+  $overridden_hash = merge($encrypt_hash, $config_hash)
+
   class { '::consul':
     install_method    => 'package',
     ui_package_name   => 'consul-web-ui',
     ui_package_ensure => 'absent',
     bin_dir           => '/usr/bin',
-    config_hash       => $config_hash,
+    config_hash       => $overridden_hash,
     purge_config_dir  => true,
   }
   exec { "reload-consul":


### PR DESCRIPTION
This patch adds encryption for consul
gossip by default. It uses the first
16 bytes of the consul discovery token
to ensure a reasonable configuration that
will be unique for each cluster.

It is also possible to override that
key using hiera.

This patch should solve a few things:

1. allows encryption of gossip traffic
2. ensures that only hosts that know
the shared secret can use gossip protocol

2 should also solve the accidental cluster
joining as a side effect