### PR TITLE
Fix sudo conf for user account which have dot in the name

### DIFF
--- a/manifests/system/accounts/sudo/conf.pp
+++ b/manifests/system/accounts/sudo/conf.pp
@@ -7,7 +7,8 @@ define rjil::system::accounts::sudo::conf (
   $commands_allowed = [],
 ) {
 
-  $cmdalias_name_uc = upcase($user)
+  $user_for_sudo = regsubst($user,'\.','','G')
+  $cmdalias_name_uc = upcase($user_for_sudo)
 
   ##
   # empty array in commands allowed means all commands are allowed (isn't it okay?)


### PR DESCRIPTION
sudo_conf break in case a user account have a dot in their username, and they
are not "admins". This is because sudo doesnt support dot or dash in the command
alias name. Fixing that problem here.