### PR TITLE
UC|more overcast specific changes

### DIFF
--- a/.overcast.yaml
+++ b/.overcast.yaml
@@ -36,7 +36,7 @@ overcloud:
       retry-wait: 5s
 undercloud:
   - shell:
-      cmd: "build_scripts/make_userdata.sh > userdata.txt"
+      cmd: "unset env_http_proxy env_https_proxy; build_scripts/make_userdata.sh > userdata.txt"
   - provision:
       stack: environment/undercloud.yaml
       userdata: userdata.txt

--- a/build_scripts/deploy.sh
+++ b/build_scripts/deploy.sh
@@ -16,9 +16,13 @@ fi
 
 ##
 # overcast can run scripts independantly, so no need to run anything else.
+# overcast is not able to resolve the environment variables in case of remote
+# exec, added an issue there in overcast. Until that fixed, we have to use
+# jiocloud module for the validation and all.
 ##
+
 if [ $provisioner == 'overcast' ]; then
-    overcast deploy --cfg ${overcast_yaml:-.overcast.yaml} --cleanup cleanup-${project_tag} --suffix ${project_tag} ${mappings_arg} --key ${ssh_key_file:-${HOME}/.ssh/id_rsa.pub} ${stack:-overcloud}
+    overcast deploy --cfg ${overcast_yaml:-.overcast.yaml} --cleanup "${cleanup_dir}./cleanup-${project_tag}" --suffix ${project_tag} ${mappings_arg} --key ${ssh_key_file:-${HOME}/.ssh/id_rsa.pub} ${stack:-overcloud}
 else
     . $(dirname $0)/make_userdata.sh
 
@@ -30,14 +34,14 @@ else
         sleep 270
         nova list | grep test${BUILD_NUMBER} | cut -f2 -d' ' | while read uuid; do nova console-log $uuid | grep Giving.up.on.md && nova reboot $uuid || true; done
     fi
-
-    time $timeout 1200 bash -c 'while ! bash -c "ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag});ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \${ssh_user:-jenkins}@\${ip} python -m jiocloud.orchestrate ping"; do sleep 5; done'
-
-    ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag})
-
-    time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate trigger_update ${BUILD_NUMBER}; do sleep 5; done"
-
-    time $timeout 4000 bash -c "while ! python -m jiocloud.apply_resources list --project_tag=${project_tag} environment/${layout}.yaml | sed -e 's/_/-/g' | ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate verify_hosts ${BUILD_NUMBER} ; do sleep 5; done"
-    time $timeout 2400 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate check_single_version -v ${BUILD_NUMBER} ; do sleep 5; done"
-    time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate get_failures --hosts; do sleep 5; done"
 fi
+
+
+ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag})
+
+time $timeout 1200 bash -c "while ! bash -c 'ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate ping'; do sleep 5; done"
+time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate trigger_update ${BUILD_NUMBER}; do sleep 5; done"
+
+time $timeout 4000 bash -c "while ! python -m jiocloud.apply_resources list --project_tag=${project_tag} environment/${layout}.yaml | sed -e 's/_/-/g' | ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate verify_hosts ${BUILD_NUMBER} ; do sleep 5; done"
+time $timeout 2400 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate check_single_version -v ${BUILD_NUMBER} ; do sleep 5; done"
+time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate get_failures --hosts; do sleep 5; done"

--- a/build_scripts/deploy.sh
+++ b/build_scripts/deploy.sh
@@ -35,9 +35,12 @@ else
         nova list | grep test${BUILD_NUMBER} | cut -f2 -d' ' | while read uuid; do nova console-log $uuid | grep Giving.up.on.md && nova reboot $uuid || true; done
     fi
 fi
+unset ip
 
-
-ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag})
+while [[ ! $ip ]] ; do
+  ip=$(python -m jiocloud.utils get_ip_of_node ${consul_bootstrap_node:-bootstrap1}_${project_tag})
+  sleep 2;
+done
 
 time $timeout 1200 bash -c "while ! bash -c 'ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate ping'; do sleep 5; done"
 time $timeout 600 bash -c "while ! ssh -o LogLevel=Error -o ServerAliveInterval=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${ssh_user:-jenkins}@${ip} python -m jiocloud.orchestrate trigger_update ${BUILD_NUMBER}; do sleep 5; done"

--- a/environment/undercloud.yaml
+++ b/environment/undercloud.yaml
@@ -1,6 +1,6 @@
 nodes:
   uc1:
-    flavor: uc
+    flavor: medium
     image: trusty
     disk: 100
     networks:


### PR DESCRIPTION
* Disabling debug as the code within debug function will not work with overcast.
* Fix wrong flavor reference
* unset env_http[s]_proxy before running make_userdata.sh
* Added validation stuffs for undercloud to .overcast.yaml
* it seems overcast has a bug because of which the variable is not getting
extracted properly on remote execution commands, because of which verify_hosts,
trigger_update etc are failing using overcast. Added an issue for that, for now
using python jiocloud directly from deploy.sh.
* save cleanup files in ~/ so they can be used by delete job.
* get_ip_of_node once rather than in a loop - ip will be assigned before that
get exeecuted