### PR TITLE
Set shell as bash for files/tests/nagios_killall

### DIFF
--- a/files/tests/nagios_killall_0
+++ b/files/tests/nagios_killall_0
@@ -1,9 +1,11 @@
+#!/bin/bash
 #
 # Nagios check that uses killall -0 to reliably determine if
 # a given process is running. This is written to replace
 # check_procs, which does not work well because of column
 # limits of ps
 #
+set -e
 if [ -z "$1" ]
 then
   echo "Must pass process name"


### PR DESCRIPTION
This this script uses bash specific syntax, the
shell should be set as bash explicitly
to ensure that even if it is invoked as a
regular executable that it will run as expected.

This commit also adds set -e to ensure that the script
does not proceed if any of it fails.