### PR TITLE
UC | Params to disable tests that are not possible for undercloud

### DIFF
--- a/manifests/test/neutron.pp
+++ b/manifests/test/neutron.pp
@@ -2,8 +2,20 @@
 # Class: rjil::test::neutron
 #   Adding tests for neutron services
 #
+# == Parameters
+#
+# [*fip_available*]
+#   This tell whether fip is available for the cloud or not, if not available
+#   do not test them.
+#
+# [*test_netcreate*]
+#   whether to test network/subnet creation - this may not be possible for
+#   undercloud.
+#
 
 class rjil::test::neutron(
+  $fip_available  = true,
+  $test_netcreate = true
 ) {
 
   include openstack_extras::auth_file
@@ -11,16 +23,18 @@ class rjil::test::neutron(
   include rjil::test::base
 
   file { '/usr/lib/jiocloud/tests/neutron-service.sh':
-    source => 'puppet:///modules/rjil/tests/neutron.sh',
+    content => template("rjil/tests/neutron.sh.erb"),
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
   }
 
-  file { '/usr/lib/jiocloud/tests/floating_ip.sh':
-    source => 'puppet:///modules/rjil/tests/floating_ip.sh',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
+  if $fip_available {
+    file { '/usr/lib/jiocloud/tests/floating_ip.sh':
+      source => 'puppet:///modules/rjil/tests/floating_ip.sh',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
   }
 }

--- a/spec/classes/test/neutron_spec.rb
+++ b/spec/classes/test/neutron_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'hiera-puppet-helper'
 
 describe 'rjil::test::neutron' do
 
@@ -8,14 +9,21 @@ describe 'rjil::test::neutron' do
     }
   end
 
+  let :facts do
+    {
+      'hostname' => 'node1'
+    }
+  end
+
   context 'with defaults' do
     it do 
       should contain_class('rjil::test::base')
+      should contain_class('openstack_extras::auth_file')
     end
 
     it do
       should contain_file('/usr/lib/jiocloud/tests/neutron-service.sh') \
-        .with_source('puppet:///modules/rjil/tests/neutron.sh') \
+        .with_content(/neutron net-create/) \
         .with_owner('root') \
         .with_group('root') \
         .with_mode('0755')
@@ -27,6 +35,22 @@ describe 'rjil::test::neutron' do
         .with_owner('root') \
         .with_group('root') \
         .with_mode('0755')
+    end
+  end
+
+  context 'without fip_available, test_netcreate' do
+    let :params do
+      {
+        :test_netcreate => false,
+        :fip_available  => false,
+      }
+    end
+
+    it do
+      should_not contain_file('/usr/lib/jiocloud/tests/neutron-service.sh') \
+        .with_content(/neutron net-create/)
+
+      should_not contain_file('/usr/lib/jiocloud/tests/floating_ip.sh')
     end
   end
 

--- a/templates/tests/neutron.sh.erb
+++ b/templates/tests/neutron.sh.erb
@@ -1,21 +1,25 @@
 #!/bin/bash
 set -e
 function fail {
-  eval $cleanup_command
   echo "CRITICAL: $@"
   exit 2
 }
 
 if [ -f /root/openrc ]; then
   source /root/openrc
-  netname=`hostname`
   neutron net-list -D || fail 'neutron net-list failed'
+  <% if @test_netcreate -%>
+  netname=`hostname`
+  for net in `neutron net-list -D | grep $netname | awk '/[a-z][a-z]*[0-9][0-9]*/ {print $2}'`; do
+    echo "Found unexpected network leftover from previous test"
+    neutron net-delete $net || fail 'neutron net-delete failed'
+  done
   netid=`neutron net-create $netname | grep ' id ' | awk  '{print $4}'` || fail 'failed to create network'
-  cleanup_command="neutron net-delete ${netid}"
   neutron subnet-create $netid 10.0.0.0/24 || fail 'neutron subnet-create failed'
   portid=`neutron port-create $netid | grep ' id ' | awk  '{print $4}'` || fail 'neutron port-create failed'
-  cleanup_command="neutron port-delete ${portid} ; ${cleanup_command}"
-  eval $cleanup_command || fail "Could not cleanup, retrying"
+  neutron port-delete $portid || fail "Could not delete port $portid"
+  neutron net-delete $netid || fail "Could not delete network $netid"
+  <% end -%>
 else
   echo 'Critical: Openrc does not exist'
   exit 2


### PR DESCRIPTION
Provided params to rjil::test::neutron to diabled the tests to create networks
and fips as they are not possible to be run for undercloud.