### PR TITLE
contrail upgrade test

### DIFF
--- a/site.pp
+++ b/site.pp
@@ -4,7 +4,7 @@ node /^bootstrap\d+/ {
   include rjil::base
   include rjil::jiocloud::consul::consul_alerts
 }
-##
+## saju cntl_upgrade_test
 # setup ceph configuration and osds on st nodes
 # These nodes wait at least one stmon to be registered in consul.
 ##


### PR DESCRIPTION
contrail upgrade test R1.1 to R2.1
Required a new build.
Old build puppet-rjil-gate-1659 is not working properly, "$sudo apt-get update" fails with Error ==>
E: Failed to fetch http://jiocloud.rustedhalo.com/ubuntu/pool/main/r/rjil-cicd/rjil-cicd_2014.2.218_all.deb  Unable to connect to jiocloud.rustedha$
o.com:http: