### PR TITLE
update sudo users for vagrant env

### DIFF
--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -17,7 +17,9 @@ nova::compute::libvirt::libvirt_virt_type: qemu
 rjil::jiocloud::consul::service::interval: 120s
 
 rjil::system::accounts::active_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,alokjani,amar,ynshenoy,abhishekl,soumit,anshup,varunarya,prashant,punituee]
-rjil::system::accounts::sudo_users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,alokjani,amar,ynshenoy,abhishekl,soumit,anshup,varunarya,prashant,punituee]
+rjil::system::accounts::sudo_users:
+  admin:
+    users: [soren,bodepd,hkumar,jenkins,consul,pandeyop,jaspreet,vivek,ahmad,vaidy,himanshu,rohit,sanjayu,alokjani,amar,ynshenoy,abhishekl,soumit,anshup,varunarya,prashant,punituee]
 ceph::conf::mon_timecheck_interval: 30
 
 ##


### PR DESCRIPTION
the format for sudoers to be passed from hiera
has changed, but the hiera config for vagrant
had not been changed. This resulted in a Puppet
compile error.

this patch updates the config in hiera.