### PR TITLE
Add service selection code for os objects

### DIFF
--- a/manifests/openstack_objects.pp
+++ b/manifests/openstack_objects.pp
@@ -11,6 +11,10 @@ class rjil::openstack_objects(
   $users             = {},
   $tenants           = undef,
   $lb_available      = true,
+  $keystone_enabled  = true,
+  $glance_enabled    = true,
+  $neutron_enabled   = true,
+  $tempest_enabled   = true,
 ) {
 
   if $override_ips {
@@ -44,37 +48,46 @@ class rjil::openstack_objects(
     fail => $fail
   }
 
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_user<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_role<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_tenant<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_service<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_endpoint<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$glance_service_name]
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$neutron_service_name]
+  if $keystone_enabled {
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_user<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_role<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_tenant<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_service<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_endpoint<||>
+    # provision keystone objects for all services
+    include openstack_extras::keystone_endpoints
+    # provision tempest resources like images, network, users etc.
+    create_resources('rjil::keystone::user',$users)
 
-  ensure_resource('rjil::service_blocker', $glance_service_name, {})
-  ensure_resource('rjil::service_blocker', $neutron_service_name, {})
-
-  Rjil::Service_blocker[$glance_service_name] -> Glance_image<||>
-  Rjil::Service_blocker[$neutron_service_name] -> Neutron_network<||>
-
-  # provision keystone objects for all services
-  include openstack_extras::keystone_endpoints
-  # provision tempest resources like images, network, users etc.
-  include tempest::provision
-
-  # create users, tenants, roles, default networks
-  create_resources('rjil::keystone::user',$users)
-
-  ##
-  # Tenants can be created without creating users, $tenants can be an array of
-  # all tenant names to be created, and a hash of tenants with appropriate
-  # params for rjil::keystone::tenant
-  ##
-  if is_array($tenants) {
-    rjil::keystone::tenant { $tenants: }
-  } elsif is_hash($tenants) {
-    create_resources('rjil::keystone::tenants',$tenants)
+    ##
+    # Tenants can be created without creating users, $tenants can be an array of
+    # all tenant names to be created, and a hash of tenants with appropriate
+    # params for rjil::keystone::tenant
+    ##
+    if is_array($tenants) {
+      rjil::keystone::tenant { $tenants: }
+    } elsif is_hash($tenants) {
+      create_resources('rjil::keystone::tenants',$tenants)
+    }
+  }
+  if $glance_enabled {
+    ensure_resource('rjil::service_blocker', $glance_service_name, {})
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$glance_service_name]
+    Rjil::Service_blocker[$glance_service_name] -> Glance_image<||>
+    include ::archive
+    archive { '/usr/lib/jiocloud/cirros-0.3.3-x86_64-disk.img':
+      source   => 'http://download.cirros-cloud.net/0.3.3/cirros-0.3.3-x86_64-disk.img',
+      before   => Glance_image['cirros-0.3.3'],
+    }
+    # create users, tenants, roles, default networks
+  }
+  if $neutron_enabled {
+    ensure_resource('rjil::service_blocker', $neutron_service_name, {})
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$neutron_service_name]
+    Rjil::Service_blocker[$neutron_service_name] -> Neutron_network<||>
+  }
+  if $tempest_enabled {
+    include tempest::provision
   }
 
 }

--- a/spec/classes/openstack_objects_spec.rb
+++ b/spec/classes/openstack_objects_spec.rb
@@ -43,6 +43,10 @@ describe 'rjil::openstack_objects' do
       should contain_runtime_fail('keystone_endpoint_not_resolvable').with({
         'fail'   => false,
       })
+      should contain_class('openstack_extras::keystone_endpoints')
+      should contain_class('archive')
+      should contain_archive('/usr/lib/jiocloud/cirros-0.3.3-x86_64-disk.img')
+      should contain_class('tempest::provision')
     end
   end
   context 'without lb' do
@@ -57,6 +61,40 @@ describe 'rjil::openstack_objects' do
     it do
       should contain_rjil__service_blocker('glance')
       should contain_rjil__service_blocker('neutron')
+    end
+  end
+  context 'disable keystone' do
+    before do
+      params.merge!(:keystone_enabled => false)
+    end
+    it 'should not contain keystone objects' do
+      should_not contain_class('openstack_extras::keystone_endpoints')
+    end
+  end
+  context 'disable glance' do
+    before do
+      params.merge!(:glance_enabled => false)
+    end
+    it 'should not contain glance objects' do
+      should_not contain_rjil__service_blocker('lb.glance')
+      should_not contain_class('archive')
+      should_not contain_archive('/usr/lib/jiocloud/cirros-0.3.3-x86_64-disk.img')
+    end
+  end
+  context 'disable neutron' do
+    before do
+      params.merge!(:neutron_enabled => false)
+    end
+    it 'should not contain neutron objects' do
+      should_not contain_rjil__service_blocker('lb.neutron')
+    end
+  end
+  context 'disable tempest' do
+    before do
+      params.merge!(:tempest_enabled => false)
+    end
+    it 'should not contain tempest objects' do
+      should_not contain_class('tempest::provision')
     end
   end
 end


### PR DESCRIPTION
This code adds selection code that can be used
to determine what objects to create based on
what services exist on a given node.

This code is intended to make it easier
to support just installing subsets of the
openstack components for development.