### PR TITLE
UC| refresh apache after update_ca_cert

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -19,4 +19,8 @@ class rjil::apache (
     include apache::mod::ssl
   }
 
+  include rjil::trust_selfsigned_cert
+
+  Exec['update-cacerts'] ~> Service['httpd']
+
 }


### PR DESCRIPTION
Service restart of apache is required once ca cert is got updated, so added
appropriate refresh.