### PR TITLE
Allow --quiet to be passed to policy file

### DIFF
--- a/files/package_start_policy.sh
+++ b/files/package_start_policy.sh
@@ -1,5 +1,9 @@
-#!/bin/sh
-name="$1"
+#!/bin/bash
+if [ "${1}" = "--quiet" ]; then
+  name="$2"
+else
+  name="$1"
+fi
 sensitive_services_list=/etc/sensitive_services
 grep -x "$name" "$sensitive_services_list" && exit 101
 exit 0


### PR DESCRIPTION
Currently, our policy file completely fails
if the quiet option is passed in.

This actually causes service actions to hang b/c
--quiet is passed as the name which means that
grep expects the search string to be passed into
STDIN (thus hanging).

Adds explicity support for the --quiet flag to
ensure that service name is still captured.