### PR TITLE
Pausing puppet

### DIFF
--- a/files/maybe-upgrade.sh
+++ b/files/maybe-upgrade.sh
@@ -3,29 +3,6 @@
 # When we're run from cron, we only have /usr/bin and /bin. That won't cut it.
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-##
-# Check if puppet is enabled for this host in consul
-# Exit codes:
-# 0 = Yes
-# 9 = No (Nein)
-##
-python -m jiocloud.orchestrate check_puppet
-puppet_enabled=$?
-
-if [ "$puppet_enabled" -eq 9 ]
-  then
-    echo "[WARN]: Puppet run is disabled, exitting."
-    exit 9
-fi
-
-# Exit codes:
-# 0: Yup, there's an update
-# 1: No, no updates
-# 2: Could not reach consul, so we don't know
-# 3: Could not reach consul, but we also haven't been initialised ourselves.
-python -m jiocloud.orchestrate pending_update
-rv=$?
-
 run_puppet() {
         # ensure that our service catalog hiera data is available
         # now run puppet
@@ -51,6 +28,32 @@ validate_service() {
                 exit 1
         fi
 }
+
+#Verify validation irrespective of enable_puppet
+validate_service
+
+##
+# Check if puppet is enabled for this host in consul
+# Exit codes:
+# 0 = Yes
+# 9 = No (Nein)
+##
+python -m jiocloud.orchestrate check_puppet
+puppet_enabled=$?
+
+if [ "$puppet_enabled" -eq 9 ]
+  then
+    echo "[WARN]: Puppet run is disabled, exitting."
+    exit 9
+fi
+
+# Exit codes:
+# 0: Yup, there's an update
+# 1: No, no updates
+# 2: Could not reach consul, so we don't know
+# 3: Could not reach consul, but we also haven't been initialised ourselves.
+python -m jiocloud.orchestrate pending_update
+rv=$?
 
 if [ $rv -eq 0 ]
 then

--- a/files/maybe-upgrade.sh
+++ b/files/maybe-upgrade.sh
@@ -3,6 +3,21 @@
 # When we're run from cron, we only have /usr/bin and /bin. That won't cut it.
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+##
+# Check if puppet is enabled for this host in consul
+# Exit codes:
+# 0 = Yes
+# 9 = No (Nein)
+##
+python -m jiocloud.orchestrate check_puppet
+puppet_enabled=$?
+
+if [ "$puppet_enabled" -eq 9 ]
+  then
+    echo "[WARN]: Puppet run is disabled, exitting."
+    exit 9
+fi
+
 # Exit codes:
 # 0: Yup, there's an update
 # 1: No, no updates


### PR DESCRIPTION
Presently the only way to disable puppet is to disable the cron
This change provides for a way to check in config if puppet has to be run or not
Right now the python-jiocloud provider only has enabled_puppet True or False
Going forward, we will add the ability to "pause" puppet till a given time as well.
Though this remaining pausing change will only be python-jiocloud and nothing in puppet-rjil.