### PR TITLE
UC|Uc specific changes

### DIFF
--- a/environment/jio-gate.map.ini
+++ b/environment/jio-gate.map.ini
@@ -1,0 +1,8 @@
+[images]
+trusty = 5d246189-a666-470c-8cee-36ee489cbd9e
+
+[flavors]
+small = da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+medium = da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+large = da9ba7b5-be67-4a62-bb35-a362e05ba2f2
+storage = da9ba7b5-be67-4a62-bb35-a362e05ba2f2

--- a/manifests/ironic.pp
+++ b/manifests/ironic.pp
@@ -101,4 +101,15 @@ class rjil::ironic(
     type       => 'proc',
   }
 
+  ##
+  # Workaround on package issue on ironic
+  ##
+  ::sudo::conf { 'ironic':
+    ensure  => present,
+    content => "#Managed By Puppet
+Defaults:ironic !requiretty
+ironic ALL = (root) NOPASSWD: /usr/bin/ironic-rootwrap",
+    require => User['ironic'],
+  }
+
 }

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -48,6 +48,7 @@ class rjil::nova::compute (
   ##
   if $compute_driver == 'libvirt' {
     include ::nova::compute::neutron
+    include ::nova::compute::libvirt
 
     Package['libvirt'] -> Exec['rm_virbr0']
 
@@ -59,6 +60,8 @@ class rjil::nova::compute (
     if $rbd_enabled {
       include ::rjil::nova::compute::rbd
     }
+  } elsif $compute_driver == 'ironic' {
+    include ::nova::compute::ironic
   }
 
 
@@ -96,5 +99,15 @@ class rjil::nova::compute (
     command     => 'true ; cd /sys/class/net ; for x in *; do ethtool -K $x gro off || true; done',
     path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
     refreshonly => true
+  }
+
+  ##
+  # Remove /etc/nova/nova-compute.conf as this file is created by ubuntu
+  # package, which is not used in case of puppet but compute driver will be
+  # overridden by default entry created in this file.
+  ##
+  file {'/etc/nova/nova-compute.conf':
+    ensure  => present,
+    content => '',
   }
 }

--- a/spec/classes/ironic_spec.rb
+++ b/spec/classes/ironic_spec.rb
@@ -118,6 +118,14 @@ describe 'rjil::ironic' do
         )
 
         should contain_rjil__jiocloud__consul__service('ironic-conductor').with_tags('real')
+
+        should contain_sudo__conf('ironic').with(
+          {
+            :ensure  => 'present',
+            :content => "#Managed By Puppet\nDefaults:ironic !requiretty\nironic ALL = (root) NOPASSWD: /usr/bin/ironic-rootwrap",
+            :require => 'User[ironic]'
+          }
+        )
     end
   end
 

--- a/spec/classes/nova/compute_spec.rb
+++ b/spec/classes/nova/compute_spec.rb
@@ -83,6 +83,13 @@ describe 'rjil::nova::compute' do
 
       should contain_package('libvirt').that_comes_before('Exec[rm_virbr0]')
 
+      should contain_file('/etc/nova/nova-compute.conf').with(
+        {
+          :ensure  => 'present',
+          :content => '',
+        }
+      )
+
     end
   end
 


### PR DESCRIPTION
* include nova::compute::ironic in case of ironic - this will make sure that
  ironic driver will be used by nova-compute.
* create sudoers file for ironic user to run ironic-rootwrap
* remove /etc/nova/nova-compute.conf which has been installed by ubuntu packages
 which are not used and in case of ironic, it will cause overriding driver to
 libvirt