### PR TITLE
Dynamic tags for registering services for contrail upgrade procedure

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -138,7 +138,7 @@ mod 'stephenrjohnson/puppet',
   :ref => '1.0.0'
 
 mod 'jiocloud/contrail',
-  :git => "#{base_url}/jiocloud/jiocloud-contrail",
+  :git => "#{base_url}/JioCloud/jiocloud-contrail",
   :ref => 'master'
 
 mod 'deric/zookeeper',

--- a/hiera/data/clientcert/ct2-production.node.consul.yaml
+++ b/hiera/data/clientcert/ct2-production.node.consul.yaml
@@ -1,0 +1,3 @@
+### Neutron tag for registering consul service###
+## Acceptable option real/backup ####
+rjil::neutron::srv_tag: 'backup'

--- a/manifests/neutron.pp
+++ b/manifests/neutron.pp
@@ -12,6 +12,7 @@ class rjil::neutron (
   $ssl                  = false,
   $rewrites             = undef,
   $headers              = undef,
+  $srv_tag                = 'real',
 ) {
 
   ##
@@ -102,7 +103,7 @@ class rjil::neutron (
   }
 
   rjil::jiocloud::consul::service { 'neutron':
-    tags          => ['real'],
+    tags          => [$srv_tag],
     port          => $public_port,
   }
 


### PR DESCRIPTION
For contrail upgrade, we will first do the upgrade contrail  controller on another bare-metal node and then cut over the compute nodes to the new contrail controller. When deploying the new node, we need to ensure that no traffic is sent to this node before the upgrade window. Hence a hiera override is done so that the service gets registered as backup and then during the upgrade the override will be changed to point to the new server.
