### PR TITLE
Fix puppet compilation errors for contrail controller

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -664,6 +664,7 @@ contrail::rabbit_user: "%{hiera('rabbit_admin_user')}"
 contrail::rabbit_password: "%{hiera('rabbit_admin_pass')}"
 contrail::vrouter::metadata_proxy_secret: "%{hiera('nova_metadata_proxy_secret')}"
 contrail::vrouter::keystone_admin_password: "%{hiera('admin_password')}"
+contrail::interface: "%{hiera('private_interface')}"
 
 contrail::manage_repo: false
 contrail::vrouter::manage_repo: false


### PR DESCRIPTION
Puppet compilation was failing on contrail controller because the default
interface (eth0) there did not have any ip address configured.

Adding this specific hieradata will fix this error.