### PR TITLE
Enable contrail analytics on a different node

### DIFF
--- a/environment/full.yaml
+++ b/environment/full.yaml
@@ -61,3 +61,9 @@ resources:
     image: trusty
     networks: default
     boot_volume: default_volume
+  ca:
+    number: 1
+    flavor: large
+    image: trusty
+    networks: default
+    boot_volume: default_volume

--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -668,11 +668,11 @@ contrail::vrouter::keystone_admin_password: "%{hiera('admin_password')}"
 contrail::manage_repo: false
 contrail::vrouter::manage_repo: false
 contrail::neutron_ip: "%{hiera('neutron_public_address')}"
-contrail::enable_analytics: false
+
 
 contrail::vrouter::debug: true
 
-rjil::contrail::server::enable_analytics: false
+
 
 contrail::config::quota_floating_ip: 5
 contrail::config::quota_logical_router: 10

--- a/hiera/data/role/ct.yaml
+++ b/hiera/data/role/ct.yaml
@@ -1,0 +1,3 @@
+# Disabling Contrail Analytics on CT nodes
+# A new node will be used for configuring contrail analytics
+contrail::enable_analytics: false

--- a/manifests/contrail/analytics.pp
+++ b/manifests/contrail/analytics.pp
@@ -1,0 +1,31 @@
+###
+## Class: rjil::contrail
+###
+class rjil::contrail::analytics 
+ {
+  ##Include contrail collector
+  class {'::contrail':
+    enable_analytics => true,
+    enable_config    => false,
+    enable_control   => false,
+    enable_webui     => false,
+    enable_ifmap     => false,
+    config_ip        => join(service_discover_dns('real.neutron.service.consul','name')),
+  }
+
+  # Added Tests
+  rjil::test {'contrail-analytics.sh':}
+
+  rjil::jiocloud::logrotate { 'contrail-collector-daily':
+    logdir => '/var/log/contrail'
+  }
+
+  ##
+  # Deleting the default config logrotates which conflict with our changes
+  # The default configs have multiple logfiles in a single config which
+  # conflicts with our daily files setup
+  ##
+
+  rjil::jiocloud::logrotate {'contrail-api':
+    ensure => absent
+  }

--- a/manifests/contrail/server.pp
+++ b/manifests/contrail/server.pp
@@ -1,9 +1,8 @@
 ###
 ## Class: rjil::contrail
 ###
-class rjil::contrail::server (
-  $enable_analytics = true,
-) {
+class rjil::contrail::server 
+ {
 
   ##
   # Added tests
@@ -14,9 +13,9 @@ class rjil::contrail::server (
                       'contrail-webui-webserver.sh','contrail-webui-jobserver.sh']
   rjil::test {$contrail_tests:}
 
-  if $enable_analytics {
-    rjil::test {'contrail-analytics.sh':}
-  }
+#  if $enable_analytics {
+#    rjil::test {'contrail-analytics.sh':}
+#  }
 
   include ::contrail
 
@@ -57,7 +56,6 @@ class rjil::contrail::server (
   ##
   $contrail_logrotate_delete = ['contrail-config',
                                 'contrail-config-openstack',
-                                'contrail-analytics',
                                 'ifmap-server',
                                 ]
   rjil::jiocloud::logrotate { $contrail_logrotate_delete:

--- a/site.pp
+++ b/site.pp
@@ -80,6 +80,15 @@ node /^ct\d+/ {
   include rjil::neutron::contrail
 }
 
+##
+## Setup Contrail Analytics Nodes
+node /^ca\d+/ {
+  include rjil::base
+  include rjil::redis
+  include rjil::cassandra
+  include rjil::contrail::analytics
+}
+
 
 ##
 ## oc is openstack controller node which will have all


### PR DESCRIPTION
Patch to have a separate node  for Contrail analytics and disabling contrail analytics on current contrail controller