### PR TITLE
make sure qemu image conversion is possible

### DIFF
--- a/manifests/tempest/provision.pp
+++ b/manifests/tempest/provision.pp
@@ -59,11 +59,17 @@ class rjil::tempest::provision (
   }
 
   if $convert_to_raw {
+
+    package {'qemu-utils':
+      ensure => installed,
+    }
+
     exec {'convert_image_to_raw':
       command => "qemu-img convert -O raw ${staging_path}/${image_name} ${staging_path}/${image_name}.img",
       creates => "${staging_path}/${image_name}.img",
-      require => Staging::File["image_stage_${image_name}"],
+      require => [ Staging::File["image_stage_${image_name}"], Package['qemu-utils']],
     }
+
     $image_source_path = "${staging_path}/${image_name}.img"
     $disk_format_l = 'raw'
   } else {

--- a/spec/classes/tempest_provision_spec.rb
+++ b/spec/classes/tempest_provision_spec.rb
@@ -63,11 +63,13 @@ describe 'rjil::tempest::provision' do
         }
       )
 
+      should contain_package('qemu-utils')
+
       should contain_exec('convert_image_to_raw').with(
         {
           :command => 'qemu-img convert -O raw /opt/staging/cirros /opt/staging/cirros.img',
           :creates => '/opt/staging/cirros.img',
-          :require => 'Staging::File[image_stage_cirros]',
+          :require => '[Staging::File[image_stage_cirros]{:name=>"image_stage_cirros"}, Package[qemu-utils]{:name=>"qemu-utils"}]',
         }
       )
 


### PR DESCRIPTION
Sometimes qemu-utils package which provide the command qemu-img is not
installed, in which case the image conversion fail. This will make sure the
command is available.