### PR TITLE
stdlib upgrade + puppet-consul revision

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -100,7 +100,7 @@ fixtures:
       ref: 4.0.0
     stdlib:
       repo: https://github.com/puppetlabs/puppetlabs-stdlib
-      ref: 4.3.2
+      ref: 4.8.0
     vswitch:
       repo: https://github.com/stackforge/puppet-vswitch
       ref: 0.3.0
@@ -112,7 +112,7 @@ fixtures:
       ref: origin/master
     consul:
       repo: https://github.com/solarkennedy/puppet-consul
-      ref: origin/master
+      ref: 3128b476b1f6ea695cac1f772f262c078c853032
     ntp:
       repo: https://github.com/puppetlabs/puppetlabs-ntp
       ref: 3.0.1

--- a/Puppetfile
+++ b/Puppetfile
@@ -115,7 +115,7 @@ mod 'puppetlabs/rabbitmq',
 
 mod 'puppetlabs/stdlib',
   :git => "#{base_url}/puppetlabs/puppetlabs-stdlib",
-  :ref => '4.3.2'
+  :ref => '4.8.0'
 
 mod 'stackforge/vswitch',
   :git => "#{base_url}/stackforge/puppet-vswitch",
@@ -155,7 +155,7 @@ mod 'puppet-modules/common',
 
 mod 'solarkennedy/consul',
   :git => "#{base_url}/solarkennedy/puppet-consul",
-  :ref => 'origin/master'
+  :ref => '3128b476b1f6ea695cac1f772f262c078c853032'
 
 mod 'jiocloud/openstack_zeromq',
   :git => "#{base_url}/jiocloud/puppet-openstack_zeromq"


### PR DESCRIPTION
Upgrading stdlib as one of the new commits in puppet-consul
needs stdlib nees validate_integer which is in stdlib >4.6.0
Also, fixing the puppet-consul version to latest revision
to avoid such surprises going further