### PR TITLE
(WIP) Keystone consul templates

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -207,3 +207,11 @@ mod 'community/archive',
 mod 'pdxcat/collectd',
   :git => "#{base_url}/pdxcat/puppet-module-collectd",
   :ref => 'v3.2.0'
+
+mod 'gdhbashton/consul_template',
+  :git => "#{base_url}/gdhbashton/puppet-consul_template",
+  :ref => 'd76c1f62d744ab1c9b12c8fc6f17a5576e1da49b'
+
+mod 'bodepd/haproxy_consul',
+  :git => "#{base_url}/bodepd/puppet-haproxy_consul",
+  :ref => 'dd354f62fe6c513dc5595949f6af04f46b1bdab1'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,6 +70,8 @@ Vagrant.configure("2") do |config|
 
       config.vm.provision 'shell', :inline =>
       "echo env=#{environment} > /etc/facter/facts.d/env.txt"
+      config.vm.provision 'shell', :inline =>
+      "echo layout=#{layout} > /etc/facter/facts.d/layout.txt"
 
       if ENV['http_proxy']
         config.vm.provision 'shell', :inline =>

--- a/build_scripts/make_userdata.sh
+++ b/build_scripts/make_userdata.sh
@@ -104,6 +104,7 @@ echo 'consul_gossip_encrypt'=`echo ${consul_discovery_token} | cut -b 1-15 | bas
 echo 'current_version='${BUILD_NUMBER} > /etc/facter/facts.d/current_version.txt
 echo 'env='${env} > /etc/facter/facts.d/env.txt
 echo 'cloud_provider='${cloud_provider} > /etc/facter/facts.d/cloud_provider.txt
+echo 'layout'='${layout} > /etc/facter/facts.d/layout.txt'
 if [ -n "${slack_url}" ]; then
   echo 'slack_url=${slack_url}' > /etc/facter/facts.d/slack_url.txt
 fi

--- a/environment/keystone.yaml
+++ b/environment/keystone.yaml
@@ -1,0 +1,15 @@
+resources:
+  bootstrap:
+    number: 1
+    flavor: small
+    image: trusty
+    networks: default
+    boot_volume: default_volume
+    assign_floating_ip: true
+  keystonedb:
+    number: 1
+    flavor: medium
+    image: trusty
+    networks: default
+    boot_volume: default_volume
+    assign_floating_ip: true

--- a/environment/keystone.yaml
+++ b/environment/keystone.yaml
@@ -13,3 +13,15 @@ resources:
     networks: default
     boot_volume: default_volume
     assign_floating_ip: true
+  keystone:
+    number: 1
+    flavor: medium
+    image: trusty
+    networks: default
+    boot_volume: default_volume
+  haproxy:
+    number: 1
+    flavor: medium
+    image: trusty
+    networks: default
+    boot_volume: default_volume

--- a/hiera/data/layout/keystone.yaml
+++ b/hiera/data/layout/keystone.yaml
@@ -1,0 +1,9 @@
+rjil::haproxy::openstack::nova_ec2_enabled: false
+rjil::haproxy::openstack::metadata_enabled:  false
+rjil::haproxy::openstack::nova_enabled:  false
+rjil::haproxy::openstack::cinder_enabled:  false
+rjil::haproxy::openstack::glance_enabled:  false
+rjil::haproxy::openstack::neutron_enabled:  false
+rjil::haproxy::openstack::novncproxy_enable:  false
+rjil::haproxy::openstack::radosgw_enabled:  false
+rjil::haproxy::openstack::horizon_enabled:  false

--- a/hiera/data/role/keystonedb.yaml
+++ b/hiera/data/role/keystonedb.yaml
@@ -1,0 +1,11 @@
+# don't require a loadbalancer
+rjil::jiocloud::dns::entries:
+  identity.jiocloud.com:
+    cname: keystone.service.consul
+
+# disable creation of other types of non-keystone objects
+rjil::openstack_objects::glance_enabled: false
+rjil::openstack_objects::neutron_enabled: false
+rjil::openstack_objects::tempest_enabled: false
+
+rjil::keystone::disable_db_sync: false

--- a/hiera/hiera.yaml
+++ b/hiera/hiera.yaml
@@ -9,6 +9,7 @@
   - "secrets/%{env}"
   - "role/%{env}/%{jiocloud_role}"
   - "role/%{jiocloud_role}"
+  - "layout/%{layout}"
   - "hw/%{cloud_provider}/%{productname}"
   - "cloud_provider/%{cloud_provider}"
   - "env/%{env}"

--- a/manifests/haproxy_service.pp
+++ b/manifests/haproxy_service.pp
@@ -45,23 +45,23 @@ define rjil::haproxy_service(
       $balancer_ports_orig = $balancer_ports
     }
 
-    ::haproxy::listen { $name:
-      ipaddress        => $vip,
-      ports            => $listen_ports_orig,
-      mode             => $listen_mode,
-      collect_exported => false,
-      options          => $listen_options,
-      bind_options     => $bind_options
-    }
+    #::haproxy::listen { $name:
+    #  ipaddress        => $vip,
+    #  ports            => $listen_ports_orig,
+    #  mode             => $listen_mode,
+    #  collect_exported => false,
+    #  options          => $listen_options,
+    #  bind_options     => $bind_options
+    #}
 
-    ::haproxy::balancermember { $name:
-      listening_service => $name,
-      ports             => $balancer_ports_orig,
-      server_names      => $cluster_addresses,
-      ipaddresses       => $cluster_addresses,
-      options           => $balancer_options,
-      define_cookies    => $balancer_cookie
-    }
+    #::haproxy::balancermember { $name:
+    #  listening_service => $name,
+    #  ports             => $balancer_ports_orig,
+    #  server_names      => $cluster_addresses,
+    #  ipaddresses       => $cluster_addresses,
+    #  options           => $balancer_options,
+    #  define_cookies    => $balancer_cookie
+    #}
 
     if (is_array($listen_ports)) {
       if ($listen_ports == []) {

--- a/manifests/keystone.pp
+++ b/manifests/keystone.pp
@@ -27,6 +27,8 @@ class rjil::keystone(
     $address = $public_address
   }
 
+  include rjil::test::keystone
+
   Rjil::Test::Check {
     ssl     => $ssl,
     address => $address,

--- a/manifests/keystone.pp
+++ b/manifests/keystone.pp
@@ -109,8 +109,6 @@ class rjil::keystone(
     }
   }
 
-  Class['rjil::keystone'] -> Rjil::Service_blocker<| title == 'keystone-admin' |>
-
   $keystone_logs = ['keystone-manage',
                     'keystone-all',
                     ]

--- a/manifests/openstack_objects.pp
+++ b/manifests/openstack_objects.pp
@@ -12,6 +12,10 @@ class rjil::openstack_objects(
   $tenants           = undef,
   $roles             = undef,
   $lb_available      = true,
+  $keystone_enabled  = true,
+  $glance_enabled    = true,
+  $neutron_enabled   = true,
+  $tempest_enabled   = true,
 ) {
 
   if $override_ips {
@@ -45,37 +49,46 @@ class rjil::openstack_objects(
     fail => $fail
   }
 
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_user<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_role<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_tenant<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_service<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_endpoint<||>
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$glance_service_name]
-  Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$neutron_service_name]
+  if $keystone_enabled {
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_user<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_role<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_tenant<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_service<||>
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Keystone_endpoint<||>
+    # provision keystone objects for all services
+    include openstack_extras::keystone_endpoints
+    # provision tempest resources like images, network, users etc.
+    create_resources('rjil::keystone::user',$users)
 
-  ensure_resource('rjil::service_blocker', $glance_service_name, {})
-  ensure_resource('rjil::service_blocker', $neutron_service_name, {})
-
-  Rjil::Service_blocker[$glance_service_name] -> Glance_image<||>
-  Rjil::Service_blocker[$neutron_service_name] -> Neutron_network<||>
-
-  # provision keystone objects for all services
-  include ::openstack_extras::keystone_endpoints
-  # provision tempest resources like images, network, users etc.
-  include rjil::tempest::provision
-
-  # create users, tenants, roles, default networks
-  create_resources('rjil::keystone::user',$users)
-
-  ##
-  # Tenants can be created without creating users, $tenants can be an array of
-  # all tenant names to be created, and a hash of tenants with appropriate
-  # params for rjil::keystone::tenant
-  ##
-  if is_array($tenants) {
-    rjil::keystone::tenant { $tenants: }
-  } elsif is_hash($tenants) {
-    create_resources('rjil::keystone::tenants',$tenants)
+    ##
+    # Tenants can be created without creating users, $tenants can be an array of
+    # all tenant names to be created, and a hash of tenants with appropriate
+    # params for rjil::keystone::tenant
+    ##
+    if is_array($tenants) {
+      rjil::keystone::tenant { $tenants: }
+    } elsif is_hash($tenants) {
+      create_resources('rjil::keystone::tenants',$tenants)
+    }
+  }
+  if $glance_enabled {
+    ensure_resource('rjil::service_blocker', $glance_service_name, {})
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$glance_service_name]
+    Rjil::Service_blocker[$glance_service_name] -> Glance_image<||>
+    include ::archive
+    archive { '/usr/lib/jiocloud/cirros-0.3.3-x86_64-disk.img':
+      source   => 'http://download.cirros-cloud.net/0.3.3/cirros-0.3.3-x86_64-disk.img',
+      before   => Glance_image['cirros-0.3.3'],
+    }
+    # create users, tenants, roles, default networks
+  }
+  if $neutron_enabled {
+    ensure_resource('rjil::service_blocker', $neutron_service_name, {})
+    Runtime_fail['keystone_endpoint_not_resolvable'] -> Rjil::Service_blocker[$neutron_service_name]
+    Rjil::Service_blocker[$neutron_service_name] -> Neutron_network<||>
+  }
+  if $tempest_enabled {
+    include tempest::provision
   }
 
   if is_array($roles) {

--- a/manifests/openstack_objects.pp
+++ b/manifests/openstack_objects.pp
@@ -66,9 +66,11 @@ class rjil::openstack_objects(
     # params for rjil::keystone::tenant
     ##
     if is_array($tenants) {
-      rjil::keystone::tenant { $tenants: }
+      rjil::keystone::tenant { $tenants:
+        create_network => $neutron_enabled,
+      }
     } elsif is_hash($tenants) {
-      create_resources('rjil::keystone::tenant',$tenants)
+      create_resources('rjil::keystone::tenant', $tenants, {'create_network' => $neutron_enabled})
     }
   }
   if $glance_enabled {

--- a/manifests/openstack_objects.pp
+++ b/manifests/openstack_objects.pp
@@ -68,7 +68,7 @@ class rjil::openstack_objects(
     if is_array($tenants) {
       rjil::keystone::tenant { $tenants: }
     } elsif is_hash($tenants) {
-      create_resources('rjil::keystone::tenants',$tenants)
+      create_resources('rjil::keystone::tenant',$tenants)
     }
   }
   if $glance_enabled {

--- a/manifests/test/haproxy_openstack.pp
+++ b/manifests/test/haproxy_openstack.pp
@@ -9,14 +9,21 @@ class rjil::test::haproxy_openstack(
   $glance_ips            = [],
   $cinder_ips            = [],
   $nova_ips              = [],
+  $keystone_enabled      = true,
+  $glance_enabled        = true,
+  $neutron_enabled       = true,
 ) {
 
   include openstack_extras::auth_file
 
   include rjil::test::base
 
-  include keystone::client
-  include glance::client
+  if $keystone_enabled {
+    include keystone::client
+  }
+  if $glance_enabled {
+    include glance::client
+  }
 
   file { "/usr/lib/jiocloud/tests/haproxy_openstack.sh":
     content => template('rjil/tests/haproxy_openstack.sh.erb'),

--- a/manifests/test/keystone.pp
+++ b/manifests/test/keystone.pp
@@ -1,0 +1,23 @@
+#
+# Class: rjil::test::keystone
+#
+# Adds a validation scripts for keystone
+#
+#
+class rjil::test::keystone {
+
+  include openstack_extras::auth_file
+
+  include rjil::test::base
+  include ::keystone::client
+
+  ensure_resource('package', 'python-keystoneclient')
+
+  file { '/usr/lib/jiocloud/tests/keystone.sh':
+    content => template('rjil/tests/keystone.sh.erb'),
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+}

--- a/site.pp
+++ b/site.pp
@@ -101,6 +101,18 @@ node /^oc\d+/ {
 # this is a variation of the controller that has a database installed
 #
 
+#
+# just keystone and a db
+#
+node /^keystonedb\d+/ {
+  include rjil::base
+  include rjil::memcached
+  include openstack_extras::client
+  include rjil::db
+  include rjil::keystone
+  include rjil::openstack_objects
+}
+
 node /^ocdb\d+/ {
   include rjil::base
   include rjil::memcached

--- a/site.pp
+++ b/site.pp
@@ -113,6 +113,13 @@ node /^keystonedb\d+/ {
   include rjil::openstack_objects
 }
 
+node /^keystone\d+/ {
+  include rjil::base
+  include rjil::memcached
+  include openstack_extras::client
+  include rjil::keystone
+}
+
 node /^ocdb\d+/ {
   include rjil::base
   include rjil::memcached

--- a/spec/classes/haproxy_openstack_spec.rb
+++ b/spec/classes/haproxy_openstack_spec.rb
@@ -73,4 +73,33 @@ describe 'rjil::haproxy::openstack' do
 
   end
 
+  describe 'with default parameters' do
+    it 'should create all ha proxy services' do
+      ['horizon', 'horizon-https', 'radosgw', 'novncproxy', 'keystone', 'keystone-admin', 'neutron', 'glance, glance-registry', 'cinder', 'nova', 'metadata', 'nova-ec2'].each do |x|
+        should contain_rjil__haproxy_service(x)
+      end
+    end
+  end
+  describe 'when services are disabled' do
+    before do
+      params.merge!(
+        'nova_ec2_enabled'  => false,
+        'metadata_enabled'  => false,
+        'nova_enabled'      => false,
+        'cinder_enabled'    => false,
+        'glance_enabled'    => false,
+        'neutron_enabled'   => false,
+        'keystone_enabled'  => false,
+        'novncproxy_enable' => false,
+        'radosgw_enabled'   => false,
+        'horizon_enabled'   => false,
+      )
+    end
+    it 'should create all ha proxy services' do
+      ['horizon', 'horizon-https', 'radosgw', 'novncproxy', 'keystone', 'keystone-admin', 'neutron', 'glance, glance-registry', 'cinder', 'nova', 'metadata', 'nova-ec2'].each do |x|
+        should_not contain_rjil__haproxy_service(x)
+      end
+    end
+  end
+
 end

--- a/spec/classes/openstack_objects_spec.rb
+++ b/spec/classes/openstack_objects_spec.rb
@@ -43,6 +43,10 @@ describe 'rjil::openstack_objects' do
       should contain_runtime_fail('keystone_endpoint_not_resolvable').with({
         'fail'   => false,
       })
+      should contain_class('openstack_extras::keystone_endpoints')
+      should contain_class('archive')
+      should contain_archive('/usr/lib/jiocloud/cirros-0.3.3-x86_64-disk.img')
+      should contain_class('tempest::provision')
     end
   end
   context 'without lb' do
@@ -57,6 +61,40 @@ describe 'rjil::openstack_objects' do
     it do
       should contain_rjil__service_blocker('glance')
       should contain_rjil__service_blocker('neutron')
+    end
+  end
+  context 'disable keystone' do
+    before do
+      params.merge!(:keystone_enabled => false)
+    end
+    it 'should not contain keystone objects' do
+      should_not contain_class('openstack_extras::keystone_endpoints')
+    end
+  end
+  context 'disable glance' do
+    before do
+      params.merge!(:glance_enabled => false)
+    end
+    it 'should not contain glance objects' do
+      should_not contain_rjil__service_blocker('lb.glance')
+      should_not contain_class('archive')
+      should_not contain_archive('/usr/lib/jiocloud/cirros-0.3.3-x86_64-disk.img')
+    end
+  end
+  context 'disable neutron' do
+    before do
+      params.merge!(:neutron_enabled => false)
+    end
+    it 'should not contain neutron objects' do
+      should_not contain_rjil__service_blocker('lb.neutron')
+    end
+  end
+  context 'disable tempest' do
+    before do
+      params.merge!(:tempest_enabled => false)
+    end
+    it 'should not contain tempest objects' do
+      should_not contain_class('tempest::provision')
     end
   end
 end

--- a/spec/classes/test/keystone_spec.rb
+++ b/spec/classes/test/keystone_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'hiera-puppet-helper'
+
+describe 'rjil::test::keystone' do
+
+  let :hiera_data do
+    {
+      'openstack_extras::auth_file::admin_password' => 'pass'
+    }
+  end
+
+  context 'with defaults' do
+    it 'should contain default resources' do
+      should contain_class('rjil::test::base')
+      should contain_class('openstack_extras::auth_file')
+      should contain_file('/usr/lib/jiocloud/tests/keystone.sh') \
+        .with_content(/keystone catalog/) \
+        .with_owner('root') \
+        .with_group('root') \
+        .with_mode('0755')
+      should contain_package('python-keystoneclient')
+    end
+  end
+
+end

--- a/templates/haproxy.cfg.erb
+++ b/templates/haproxy.cfg.erb
@@ -1,0 +1,38 @@
+<%= scope.function_template(['haproxy/haproxy-base.cfg.erb']) %>
+
+listen lb-stats
+  bind 0.0.0.0:8094
+  mode  http
+  option  httplog
+  stats  enable
+  stats  uri /lb-stats
+
+<% @backends.each do |name, options| -%>
+listen <%= name %>
+<% require 'ipaddr' -%>
+<% Array(options['vip'] || ['0.0.0.0']).uniq.each do |virtual_ip| (Array(options['ports']) || []).each do |port| -%>
+  <%-
+    begin
+      IPAddr.new(virtual_ip)
+      valid_ip = true
+    rescue ArgumentError => e
+      valid_ip = false
+    end
+    if ! valid_ip and ! virtual_ip.match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*"
+      scope.function_fail(["Invalid IP address or hostname [#{virtual_ip}]"])
+    end
+  -%>
+  <%- scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535 -%>
+  bind <%= virtual_ip %>:<%= port %> <%= Array(@bind_options).join(" ") %>
+<% end end -%>
+  mode  <%= options['mode'] || 'tcp' %>
+<% listen_options = options['listen_options'] || {'option' => 'tcpka', 'option' => 'abortonclose', 'balance' => 'roundrobin'} -%>
+<% listen_options.sort.each do |key, val| -%>
+<% Array(val).each do |item| -%>
+  <%= key %>  <%= item %>
+<% end -%>
+<% end -%>
+{{range service "<%= options['service_name'] || name %>"}}
+server {{.ID}} {{.Address}}:{{.Port}} <%= options['options'] || 'check inter 10s rise 2 fall 3' %>
+{{end}}
+<% end %>

--- a/templates/tests/haproxy_openstack.sh.erb
+++ b/templates/tests/haproxy_openstack.sh.erb
@@ -2,6 +2,12 @@
 set -e
 test -f /root/openrc
 source /root/openrc
+<% if @keystone_enabled -%>
 keystone catalog
+<% end -%>
+<% if @glance_enabled -%>
 glance image-list
+<% end -%>
+<% if @neutron_enabled -%>
 neutron net-list
+<% end -%>

--- a/templates/tests/keystone.sh.erb
+++ b/templates/tests/keystone.sh.erb
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+test -f /root/openrc
+source /root/openrc
+keystone catalog


### PR DESCRIPTION
built on top of the keystone only deployment branch to create a prototype for consul-templates to make the haproxy config for keystone much more dynamic by using consul-templates instead of puppet to populate the host info.