### PR TITLE
Limit number of backups to 240 per customer account

### DIFF
--- a/hiera/data/common.yaml
+++ b/hiera/data/common.yaml
@@ -331,7 +331,7 @@ cinder::volume::rbd::volume_tmp_dir: /tmp
 cinder::volume::rbd::rbd_secret_uuid: "%{hiera('cinder_rbd_secret_uuid')}"
 cinder::glance::glance_api_servers: "%{hiera('api_protocol')}://%{hiera('glance_public_address')}:%{hiera('glance_api_port')}"
 cinder::quota::quota_volumes: 120
-cinder::quota::quota_snapshots: 240
+cinder::quota::quota_backups: 240
 
 ########### Nova config
 ###################################

--- a/manifests/cinder.pp
+++ b/manifests/cinder.pp
@@ -65,6 +65,7 @@ class rjil::cinder (
   $rewrites                = undef,
   $headers                 = undef,
   $use_default_quota_class = false,
+  $enable_v1_api           = false,
 ) {
 
   ######################## Service Blockers and Ordering
@@ -115,6 +116,11 @@ class rjil::cinder (
   # Cinder default quotas read from the config file.
 
   cinder_config { 'DEFAULT/use_default_quota_class': value => $use_default_quota_class }
+
+  ##
+  # Cinder enable_v1_api false for disable the V1 APIs
+
+  cinder_config { 'DEFAULT/enable_v1_api': value => $enable_v1_api }
 
   ## Configure apache reverse proxy
   apache::vhost { 'cinder':


### PR DESCRIPTION
Limit number of backups to 240 per customer account
Closes-bug# https://bugs.launchpad.net/jio/+bug/1472591