### PR TITLE
Add some validation tests for keystone

### DIFF
--- a/manifests/keystone.pp
+++ b/manifests/keystone.pp
@@ -27,6 +27,8 @@ class rjil::keystone(
     $address = $public_address
   }
 
+  include rjil::test::keystone
+
   Rjil::Test::Check {
     ssl     => $ssl,
     address => $address,

--- a/manifests/test/keystone.pp
+++ b/manifests/test/keystone.pp
@@ -1,0 +1,23 @@
+#
+# Class: rjil::test::keystone
+#
+# Adds a validation scripts for keystone
+#
+#
+class rjil::test::keystone {
+
+  include openstack_extras::auth_file
+
+  include rjil::test::base
+  include ::keystone::client
+
+  ensure_resource('package', 'python-keystoneclient')
+
+  file { '/usr/lib/jiocloud/tests/keystone.sh':
+    content => template('rjil/tests/keystone.sh.erb'),
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+}

--- a/spec/classes/test/keystone_spec.rb
+++ b/spec/classes/test/keystone_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'hiera-puppet-helper'
+
+describe 'rjil::test::keystone' do
+
+  let :hiera_data do
+    {
+      'openstack_extras::auth_file::admin_password' => 'pass'
+    }
+  end
+
+  context 'with defaults' do
+    it 'should contain default resources' do
+      should contain_class('rjil::test::base')
+      should contain_class('openstack_extras::auth_file')
+      should contain_file('/usr/lib/jiocloud/tests/keystone.sh') \
+        .with_content(/keystone catalog/) \
+        .with_owner('root') \
+        .with_group('root') \
+        .with_mode('0755')
+      should contain_package('python-keystoneclient')
+    end
+  end
+
+end

--- a/templates/tests/keystone.sh.erb
+++ b/templates/tests/keystone.sh.erb
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+test -f /root/openrc
+source /root/openrc
+keystone catalog


### PR DESCRIPTION
Currently, thare are no validation tests
for keystone that do anything other than
check that the ports are bound (for consul
service checks)

This commit adds some validation tests for
keystone that verify that keystone catalog
returns something.