### PR TITLE
Fix define name tenants to tenant

### DIFF
--- a/manifests/openstack_objects.pp
+++ b/manifests/openstack_objects.pp
@@ -75,7 +75,7 @@ class rjil::openstack_objects(
   if is_array($tenants) {
     rjil::keystone::tenant { $tenants: }
   } elsif is_hash($tenants) {
-    create_resources('rjil::keystone::tenants',$tenants)
+    create_resources('rjil::keystone::tenant',$tenants)
   }
 
   if is_array($roles) {

--- a/spec/classes/openstack_objects_spec.rb
+++ b/spec/classes/openstack_objects_spec.rb
@@ -59,4 +59,26 @@ describe 'rjil::openstack_objects' do
       should contain_rjil__service_blocker('neutron')
     end
   end
+  context 'with tenants as a hash' do
+    let :params do
+      {
+        :identity_address => 'address',
+        :tenants => ['foo'],
+      }
+    end
+    it do
+      should contain_rjil__keystone__tenant('foo')
+    end
+  end
+  context 'with tenants as a hash' do
+    let :params do
+      {
+        :identity_address => 'address',
+        :tenants => {'foo' => {}}
+      }
+    end
+    it do
+      should contain_rjil__keystone__tenant('foo')
+    end
+  end
 end


### PR DESCRIPTION
Previosly, it referred to a non-existing
namespace. This commit fixes it to refer
to somethign that exists.

Also adds tests coverage for that part of
the code.